### PR TITLE
Update publish tasks to publish both flavours

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,16 +78,23 @@ configure(subprojects.findAll({ it.name in ["persistence", "synchronization", "d
             classifier "source"
         }
 
-        publish.dependsOn 'assemble'
+        publish.dependsOn 'assembleRelease'
 
         publishing {
             publications {
-                "${project.name}"(MavenPublication) {
+                "${project.name}-mock"(MavenPublication) {
                     groupId project.group
-                    artifactId project.name
+                    artifactId "${project.name}-mock"
                     version android.defaultConfig.versionName
                     artifact(sourceJar)
-                    artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+                    artifact("$buildDir/outputs/aar/${project.name}-mock-release.aar")
+                }
+                "${project.name}-full"(MavenPublication) {
+                    groupId project.group
+                    artifactId "${project.name}"
+                    version android.defaultConfig.versionName
+                    artifact(sourceJar)
+                    artifact("$buildDir/outputs/aar/${project.name}-full-release.aar")
                 }
             }
             repositories {

--- a/persistence/build.gradle
+++ b/persistence/build.gradle
@@ -28,6 +28,19 @@ android {
         buildConfigField("String", "provider", "\"de.cyface.provider\"")
         //buildConfigField("String", "testProvider", "\"de.cyface.testProvider\"") - the authority is replaced for iTs via manifest, not sure if we need to use a different provider, too?
     }
+
+    flavorDimensions "app"
+
+    productFlavors {
+        mock {
+            dimension "app"
+            versionNameSuffix "-mock"
+        }
+        full {
+            dimension "app"
+            versionNameSuffix "-full"
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Updates the publish tasks to publish both flavours to the MavenLocal repository.  
The "full" flavour will continue to be published without suffix. The "mock" flavour will be published with a suffixed "-mock".