### PR TITLE
Adds the capability to provide an auth token

### DIFF
--- a/datacapturing/src/main/AndroidManifest.xml
+++ b/datacapturing/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <!-- Required to authenticate Cyface accounts with a Cyface server -->
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
+    <!-- Required to delete Cyface accounts from the Android system -->
+    <uses-permission
+        android:name="android.permission.MANAGE_ACCOUNTS"
+        android:maxSdkVersion="22" />
 
     <application>
         <!-- Declares the data capturing service which is not exported to other applications. Most important is the android:process declaration with the ":" in the beginning. It tells the system to run the service in its own process. -->

--- a/datacapturing/src/main/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -1,0 +1,39 @@
+package de.cyface.datacapturing;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import de.cyface.datacapturing.exception.SetupException;
+import de.cyface.datacapturing.exception.SynchronisationException;
+
+/**
+ * An implementation of a <code>DataCapturingService</code> using a dummy Cyface account for data synchronization.
+ *
+ * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 2.0.0
+ */
+public final class CyfaceDataCapturingService extends DataCapturingService {
+    /**
+     * Default dummy account used for data synchronization.
+     */
+    private final static String ACCOUNT = "default_account";
+
+    /**
+     * Creates a new completely initialized {@link DataCapturingService}.
+     *
+     * @param context The context (i.e. <code>Activity</code>) handling this service.
+     * @param dataUploadServerAddress The server address running an API that is capable of receiving data captured by
+     *            this service.
+     * @throws SetupException If writing the components preferences or registering the dummy user account fails.
+     */
+    public CyfaceDataCapturingService(@NonNull Context context, @NonNull String dataUploadServerAddress)
+            throws SetupException {
+        super(context, dataUploadServerAddress);
+        try {
+            setCurrentSynchronizationAccount(ACCOUNT);
+        } catch (SynchronisationException e) {
+            throw new SetupException(e);
+        }
+    }
+}

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -110,6 +110,9 @@ public abstract class DataCapturingService {
      */
     private Messenger toServiceMessenger;
 
+    /**
+     * The <code>Account</code> currently used for data synchronization or <code>null</code> if no such <code>Account</code> has been set.
+     */
     private Account currentSynchronizationAccount;
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -4,6 +4,7 @@ import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
 
+import android.annotation.SuppressLint;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -68,6 +69,10 @@ public class DataCapturingBackgroundService extends Service implements Capturing
      */
     private CapturingNotification capturingNotification;
 
+    /**
+     * A facade handling reading and writing data from and to the Android content provider used to store and retrieve
+     * measurement data.
+     */
     private MeasurementPersistence persistenceLayer;
 
     /*
@@ -92,6 +97,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
         super.onRebind(intent);
     }
 
+    @SuppressLint("WakelockTimeout") // We can not provide a timeout since our service might need to run for hours.
     @Override
     public void onCreate() {
         super.onCreate();

--- a/datacapturing/src/test/java/de/cyface/datacapturing/backend/DataCapturingTest.java
+++ b/datacapturing/src/test/java/de/cyface/datacapturing/backend/DataCapturingTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * <p> Tests the correct workings of the data capturing functionality. </p>
+ * Tests the correct workings of the data capturing functionality.
  *
  * @author Klemens Muthmann
  * @version 1.0.0
@@ -69,9 +69,9 @@ public class DataCapturingTest {
     }
 
     /**
-     * <p> Tests whether a point captured event is successfully issued after two gps points and one
+     * Tests whether a point captured event is successfully issued after two gps points and one
      * satellite status event are received and the two gps points occured in short succession.
-     * Usually below 2 seconds. </p>
+     * Usually below 2 seconds.
      *
      * @throws Exception If anything went wrong.
      */

--- a/synchronization/src/androidTest/java/de/cyface/synchronization/MovebisDataTransmissionTest.java
+++ b/synchronization/src/androidTest/java/de/cyface/synchronization/MovebisDataTransmissionTest.java
@@ -110,6 +110,7 @@ public class MovebisDataTransmissionTest {
             MeasurementLoader loader = new MeasurementLoader(measurementIdentifier, client);
             MeasurementSerializer serializer = new MeasurementSerializer();
             InputStream measurementData = serializer.serialize(loader);
+            String jwtAuthToken = "replaceMe";
 
             SyncPerformer performer = new SyncPerformer(InstrumentationRegistry.getTargetContext());
             int result = performer.sendData("https://localhost:8080", measurementIdentifier, "garbage", measurementData,
@@ -118,7 +119,7 @@ public class MovebisDataTransmissionTest {
                         public void updatedProgress(float percent) {
                             Log.d(TAG, String.format("Upload Progress %f", percent));
                         }
-                    });
+                    }, jwtAuthToken);
             assertThat(result, is(equalTo(201)));
         } finally {
             if (client != null) {

--- a/synchronization/src/full/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/full/java/de/cyface/synchronization/SyncPerformer.java
@@ -93,10 +93,12 @@ class SyncPerformer {
      * @param deviceIdentifier The device identifier of the device transmitting the measurement.
      * @param data The data to transmit as <code>InputStream</code>.
      * @param progressListener A listener that is informed about the progress of the upload.
+     * @param jwtAuthToken A valid JWT auth token to authenticate the transmission
      * @return The <a href="https://de.wikipedia.org/wiki/HTTP-Statuscode">HTTP status</a> code of the response.
      */
-    int sendData(final String dataServerUrl, final long measurementIdentifier, final String deviceIdentifier,
-            final @NonNull InputStream data, final @NonNull UploadProgressListener progressListener) {
+    int sendData(final @NonNull String dataServerUrl, final long measurementIdentifier,
+            final @NonNull String deviceIdentifier, final @NonNull InputStream data,
+            final @NonNull UploadProgressListener progressListener, final @NonNull String jwtAuthToken) {
         Log.i(TAG, String.format(Locale.US, "Uploading data from device %s with identifier %s to server %s",
                 deviceIdentifier, measurementIdentifier, dataServerUrl));
         HttpsURLConnection.setFollowRedirects(false);
@@ -117,7 +119,7 @@ class SyncPerformer {
             } catch (ProtocolException e) {
                 throw new IllegalStateException(e);
             }
-            connection.setRequestProperty("Authorization", "Bearer test");
+            connection.setRequestProperty("Authorization", jwtAuthToken);
             String boundary = "---------------------------boundary";
             String tail = "\r\n--" + boundary + "--\r\n";
             connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);

--- a/synchronization/src/main/AndroidManifest.xml
+++ b/synchronization/src/main/AndroidManifest.xml
@@ -1,10 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.cyface.synchronization" >
+    <!-- Required to transmit data to a server -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.READ_SYNC_STATS"/>
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
+    <!-- Required to load the current user account from the system -->
+    <!--<uses-permission android:name="android.permission.GET_ACCOUNTS"/>-->
+    <!-- Required to read JWT auth token from user account -->
+    <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
 
     <application>
         <service android:name="de.cyface.synchronization.SyncService"

--- a/synchronization/src/main/java/de/cyface/synchronization/CyfaceSyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/CyfaceSyncAdapter.java
@@ -1,8 +1,14 @@
 package de.cyface.synchronization;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
 import android.content.AbstractThreadedSyncAdapter;
 import android.content.ContentProviderClient;
 import android.content.Context;
@@ -89,19 +95,28 @@ public final class CyfaceSyncAdapter extends AbstractThreadedSyncAdapter {
         MeasurementSerializer serializer = new MeasurementSerializer();
         SyncPerformer syncer = new SyncPerformer(getContext());
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
-
-        String endPointUrl = preferences.getString(SYNC_ENDPOINT_URL_SETTINGS_KEY, null);
-        if (endPointUrl == null) {
-            throw new IllegalStateException("Unable to read synchronization endpoint from settings!");
-        }
-
-        String deviceIdentifier = preferences.getString(DEVICE_IDENTIFIER_KEY, null);
-        if (deviceIdentifier == null) {
-            throw new IllegalStateException("Unable to read device identifier from settings!");
-        }
-
         Cursor syncableMeasurementsCursor = null;
+        AccountManager accountManager = AccountManager.get(getContext());
+        // Account[] accounts AccountManager.get(getContext()).getAccountsByType(StubAuthenticator.ACCOUNT_TYPE);
+        AccountManagerFuture<Bundle> future = accountManager.getAuthToken(account, StubAuthenticator.AUTH_TOKEN_TYPE,
+                null, false, null, null);
         try {
+            Bundle result = future.getResult(1, TimeUnit.SECONDS);
+            String jwtAuthToken = result.getString(AccountManager.KEY_AUTHTOKEN);
+            if (jwtAuthToken == null) {
+                throw new IllegalStateException("No valid auth token supplied. Aborting data synchronization!");
+            }
+
+            String endPointUrl = preferences.getString(SYNC_ENDPOINT_URL_SETTINGS_KEY, null);
+            if (endPointUrl == null) {
+                throw new IllegalStateException("Unable to read synchronization endpoint from settings!");
+            }
+
+            String deviceIdentifier = preferences.getString(DEVICE_IDENTIFIER_KEY, null);
+            if (deviceIdentifier == null) {
+                throw new IllegalStateException("Unable to read device identifier from settings!");
+            }
+
             syncableMeasurementsCursor = provider.query(MeasuringPointsContentProvider.MEASUREMENT_URI, null,
                     MeasurementTable.COLUMN_FINISHED + "=?", new String[] {Integer.valueOf(1).toString()}, null);
 
@@ -125,9 +140,9 @@ public final class CyfaceSyncAdapter extends AbstractThreadedSyncAdapter {
                                 syncProgressIntent.putExtra(SYNC_PROGRESS_KEY, percent);
                                 getContext().sendBroadcast(syncProgressIntent);
                             }
-                        });
+                        }, jwtAuthToken);
             }
-        } catch (RemoteException e) {
+        } catch (RemoteException | OperationCanceledException | AuthenticatorException | IOException e) {
             throw new IllegalStateException(e);
         } finally {
             if (syncableMeasurementsCursor != null) {

--- a/synchronization/src/main/java/de/cyface/synchronization/StubAuthenticator.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/StubAuthenticator.java
@@ -5,8 +5,11 @@ import android.accounts.Account;
 import android.accounts.AccountAuthenticatorResponse;
 import android.accounts.NetworkErrorException;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+
+import java.lang.ref.WeakReference;
 
 /**
  * Stub class for an authenticator. This is necessary since an authenticator is a requirement for a synchronisation
@@ -19,12 +22,19 @@ import android.support.annotation.NonNull;
  * @since 2.0.0
  */
 public final class StubAuthenticator extends AbstractAccountAuthenticator {
+
+    /**
+     * The Cyface account type used to identify all Cyface system accounts.
+     */
+    public final static String ACCOUNT_TYPE = "de.cyface";
+    public final static String AUTH_TOKEN_TYPE = "de.cyface.jwt";
+
     /**
      * Creates a new completely initialized <code>StubAuthenticator</code>.
      *
      * @param context The Android context for the authenticator.
      */
-    public StubAuthenticator(final @NonNull Context context) {
+    StubAuthenticator(final @NonNull Context context) {
         super(context);
     }
 

--- a/synchronization/src/mock/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/mock/java/de/cyface/synchronization/SyncPerformer.java
@@ -7,19 +7,43 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 /**
- * Created by muthmann on 26.02.18.
+ * This is a no-op implementation of a <code>SyncPerformer</code>. On call it simply ignores all arguments and simulates
+ * a successful data transmission without actually calling any network.
+ *
+ * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 2.0.0
  */
 public class SyncPerformer {
 
+    /**
+     * The tag used to identify Logcat messages from objects of this class.
+     */
     private static final String TAG = "de.cyface.sync";
 
+    /**
+     * Creates a new completely initialized <code>SyncPerformer</code> with the current Android context.
+     *
+     * @param context The current context of this object. Usually an instance of <code>SyncService</code>.
+     */
     public SyncPerformer(final @NonNull Context context) {
-
+        // Nothing to do here.
     }
 
+    /**
+     * A do nothing implementation of the data transmission method.
+     *
+     * @param endPointUrl Is ignored!
+     * @param measurementIdentifier Is ignored!
+     * @param deviceIdentifier Is ignored!
+     * @param data Is ignored!
+     * @param uploadProgressListener Is ignored!
+     * @param jwtAuthToken Is ignored!
+     * @return Always <code>201</code> which is the expected status code for a successful transmission.
+     */
     public int sendData(final @NonNull String endPointUrl, final long measurementIdentifier,
             final @NonNull String deviceIdentifier, final @NonNull InputStream data,
-            final @NonNull UploadProgressListener uploadProgressListener) {
+            final @NonNull UploadProgressListener uploadProgressListener, final @NonNull String jwtAuthToken) {
         Log.i(TAG, "Synchronizing data");
         return 201;
     }


### PR DESCRIPTION
This commit refactors the way Android accounts are added to a DataCapturingService. There is a new CyfaceDataCapturing service working with a dummy account and the MovebisDataCapturing service was extended to allow for registering and deregistering JWT auth tokens.