### PR TITLE
make methods public to be accessible from other packages

### DIFF
--- a/datacapturing/src/main/java/de/cyface/datacapturing/ShutDownFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/ShutDownFinishedHandler.java
@@ -33,7 +33,7 @@ public abstract class ShutDownFinishedHandler extends BroadcastReceiver {
     /**
      * Method called if shutdown has been finished.
      */
-    abstract void shutDownFinished();
+    abstract public void shutDownFinished();
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartSynchronizer.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartSynchronizer.java
@@ -33,7 +33,7 @@ public class StartSynchronizer extends StartUpFinishedHandler {
     }
 
     @Override
-    void startUpFinished() {
+    public void startUpFinished() {
         synchronizer.signal();
     }
 }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
@@ -34,7 +34,7 @@ public abstract class StartUpFinishedHandler extends BroadcastReceiver {
     /**
      * Method called if start up has been finished.
      */
-    abstract void startUpFinished();
+    abstract public void startUpFinished();
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StopSynchronizer.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StopSynchronizer.java
@@ -33,7 +33,7 @@ public class StopSynchronizer extends ShutDownFinishedHandler {
     }
 
     @Override
-    void shutDownFinished() {
+    public void shutDownFinished() {
         synchronizer.signal();
     }
 }


### PR DESCRIPTION
The Abstract Methods defined in `StartUpFinishedHandler` and `ShutDownFinishedHandler` should be public so they can be overridden by implementations outside the `de.cyface.datacapturing` Package.