### PR TITLE
Moves startForegroundService to onCreate

### DIFF
--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -27,6 +27,7 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import de.cyface.datacapturing.BuildConfig;
 import de.cyface.datacapturing.BundlesExtrasCodes;
 import de.cyface.datacapturing.MessageCodes;
 import de.cyface.datacapturing.exception.DataCapturingException;
@@ -62,6 +63,27 @@ public class DataCapturingBackgroundService extends Service implements Capturing
      * The maximum size of captured data transmitted to clients of this service in one call. If there are more captured points they are split into multiple messages.
      */
     final static int MAXIMUM_CAPTURED_DATA_MESSAGE_SIZE = 800;
+    /**
+     * Reference to the R files identifier for the notification channel name.
+     */
+    private final static int NOTIFICATION_CHANNEL_ID = BuildConfig.NOTIFICATION_CHANNEL;
+    /**
+     * Reference to the R files identifier for the notification title.
+     */
+    private final static int NOTIFICATION_TITEL_ID = BuildConfig.NOTIFICATION_TITLE;
+    /**
+     * Reference to the R files identifier for the notification text.
+     */
+    private final static int NOTIFICATION_TEXT_ID = BuildConfig.NOTIFICATION_TEXT;
+    /**
+     * Reference to the R files identifier for the notification logo.
+     */
+    private final static int NOTIFICATION_LOGO_ID = BuildConfig.NOTIFICATION_LOGO;
+    // TODO: Add this! But not used for the moment.
+    /**
+     * Reference to the R files identifier for the large logo shown as part of the notification.
+     */
+    private final static int NOTIFICATION_LARGE_LOGO_ID = 0;
     /**
      * A wake lock used to keep the application active during data capturing.
      */
@@ -121,6 +143,10 @@ public class DataCapturingBackgroundService extends Service implements Capturing
     public void onCreate() {
         super.onCreate();
         Log.d(TAG, "onCreate");
+        /* Notification shown to the user while the data capturing is active. */
+        // This needs to go in onCreate or it will be called to late from time to time!
+        CapturingNotification capturingNotification = new CapturingNotification(NOTIFICATION_CHANNEL_ID,NOTIFICATION_TITEL_ID,NOTIFICATION_TEXT_ID,NOTIFICATION_LOGO_ID,NOTIFICATION_LARGE_LOGO_ID);
+        startForeground(capturingNotification.getNotificationId(), capturingNotification.getNotification(this));
 
         persistenceLayer = new MeasurementPersistence(this.getContentResolver());
 
@@ -186,9 +212,6 @@ public class DataCapturingBackgroundService extends Service implements Capturing
      * available.
      */
     private void init() {
-        /* Notification shown to the user while the data capturing is active. */
-        CapturingNotification capturingNotification = new CapturingNotification();
-        startForeground(capturingNotification.getNotificationId(), capturingNotification.getNotification(this));
         LocationManager locationManager = (LocationManager)this.getSystemService(Context.LOCATION_SERVICE);
 
             GeoLocationDeviceStatusHandler gpsStatusHandler = Build.VERSION_CODES.N <= Build.VERSION.SDK_INT

--- a/datacapturing/src/main/java/de/cyface/datacapturing/ui/CapturingNotification.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/ui/CapturingNotification.java
@@ -18,7 +18,7 @@ import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
  * required to make the user aware of the background tracking. It shows up as a small symbol on the upper status bar.
  *
  * @author Klemens Muthmann
- * @version 1.0.2
+ * @version 2.0.0
  * @since 1.0.0
  */
 public class CapturingNotification {
@@ -27,6 +27,47 @@ public class CapturingNotification {
      * The Android <code>Notification</code> wrapped by this class.
      */
     private Notification wrappedNotification;
+    /**
+     * Reference to the R files identifier for the notification channel name.
+     */
+    private final int notificationChannel;
+    /**
+     * Reference to the R files identifier for the notification title.
+     */
+    private final int notificationTitel;
+    /**
+     * Reference to the R files identifier for the notification text.
+     */
+    private final int notificationText;
+    /**
+     * Reference to the R files identifier for the notification logo.
+     */
+    private final int notificationLogo;
+    // TODO: This is not used at the moment but required to finish the notification styling.
+    /**
+     * Reference to the R files identifier for the large logo shown as part of the notification.
+     */
+    private final int notificationLargeLogo;
+
+    /**
+     * Creates a new completely initialized <code>CapturingNotification</code> with a whole bunch of styling
+     * information.
+     *
+     * @param notificationChannel Reference to the R files identifier for the notification channel name.
+     * @param notificationTitel Reference to the R files identifier for the notification title.
+     * @param notificationText Reference to the R files identifier for the notification text.
+     * @param notificationLogo Reference to the R files identifier for the notification logo.
+     * @param notificationLargeLogo Reference to the R files identifier for the large logo shown as part of the
+     *            notification.
+     */
+    public CapturingNotification(final int notificationChannel, final int notificationTitel, final int notificationText,
+            final int notificationLogo, final int notificationLargeLogo) {
+        this.notificationChannel = notificationChannel;
+        this.notificationTitel = notificationTitel;
+        this.notificationText = notificationText;
+        this.notificationLogo = notificationLogo;
+        this.notificationLargeLogo = notificationLargeLogo;
+    }
 
     /**
      * @return An identifier required by the Android system to display the notification.
@@ -57,14 +98,14 @@ public class CapturingNotification {
         // cancelIntent.setAction(CANCEL_REQUEST);
         // PendingIntent pendingCancelIntent = PendingIntent.getService(
         // context, 0, cancelIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-        String channelId = context.getText(BuildConfig.NOTIFICATION_CHANNEL).toString();
+        String channelId = context.getText(notificationChannel).toString();
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             createNotificationChannelIfNotExists(context, channelId);
         }
 
         wrappedNotification = new NotificationCompat.Builder(context, channelId)
-                .setContentTitle(context.getText(BuildConfig.NOTIFICATION_TITLE))
-                .setContentText(context.getText(BuildConfig.NOTIFICATION_TEXT)).setSmallIcon(BuildConfig.NOTIFICATION_LOGO)
+                .setContentTitle(context.getText(notificationTitel)).setContentText(context.getText(notificationText))
+                .setSmallIcon(notificationLogo)
                 // .setContentIntent(pendingIntent)
                 .setTicker(context.getText(R.string.ticker_text)).build();
 
@@ -72,17 +113,19 @@ public class CapturingNotification {
     }
 
     /**
-     * Since Android 8 it is necessary to create a new notification channel for a foreground service notification. To save system resources this should only happen if the channel does not exist. This method does just that.
+     * Since Android 8 it is necessary to create a new notification channel for a foreground service notification. To
+     * save system resources this should only happen if the channel does not exist. This method does just that.
      *
      * @param context The Android <code>Context</code> to use to create the notification channel.
      * @param channelId The identifier of the created or existing channel.
      */
     @RequiresApi(api = Build.VERSION_CODES.O)
-    private void createNotificationChannelIfNotExists(final @NonNull DataCapturingBackgroundService context, final @NonNull String channelId) {
+    private void createNotificationChannelIfNotExists(final @NonNull DataCapturingBackgroundService context,
+            final @NonNull String channelId) {
         final CharSequence channelName = "Cyface";
 
         NotificationManager manager = (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
-        if(manager==null) {
+        if (manager == null) {
             throw new IllegalStateException("Manager for service notifications not available.");
         }
 


### PR DESCRIPTION
Philipp experienced an error, where startForeground was obviously not
called soon enough. According to documentation, it should be called in
onCreate rather than onStartCommand. This commit fixes this problem,
hopefully.