### PR TITLE
Add NPE check to MeasurementPersistence#delete

### DIFF
--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -45,7 +45,7 @@ import de.cyface.persistence.SamplePointTable;
  * documentation</a>.
  *
  * @author Klemens Muthmann
- * @version 3.1.1
+ * @version 4.0.0
  * @since 1.0.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -258,9 +258,12 @@ public class CapturedDataWriterTest extends ProviderTestCase2<MeasuringPointsCon
     /**
      * Tests whether loading measurements from the data storage via <code>MeasurementPersistence</code> is working as
      * expected.
+     *
+     * @throws NoSuchMeasurementException If the test measurement was null for some reason. This should only happen if
+     *             there was a very serious database error.
      */
     @Test
-    public void testLoadMeasurements() {
+    public void testLoadMeasurements() throws NoSuchMeasurementException {
         oocut.newMeasurement(Vehicle.UNKOWN);
         oocut.newMeasurement(Vehicle.CAR);
 
@@ -274,9 +277,12 @@ public class CapturedDataWriterTest extends ProviderTestCase2<MeasuringPointsCon
 
     /**
      * Tests whether deleting a measurement actually remove that measurement together with all corresponding data.
+     *
+     * @throws NoSuchMeasurementException If the test measurement was null for some reason. This should only happen if
+     *             there was a very serious database error.
      */
     @Test
-    public void testDeleteMeasurement() {
+    public void testDeleteMeasurement() throws NoSuchMeasurementException {
         Measurement measurement = oocut.newMeasurement(Vehicle.UNKOWN);
         oocut.storeData(testData(), measurement.getIdentifier());
         oocut.storeLocation(testLocation(), measurement.getIdentifier());

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -334,10 +334,13 @@ public abstract class DataCapturingService {
             setIsStoppingOrHasStopped(true);
             Measurement measurement = persistenceLayer.loadCurrentlyCapturedMeasurement();
 
-            // TODO: This should throw an exception. But since we need to handle double stop gracefully it is impossible at the moment.
-            /*if (measurement == null) {
-                throw new NoSuchMeasurementException("Unable to stop service. There was no open measurement to close.");
-            }*/
+            // TODO: This should throw an exception. But since we need to handle double stop gracefully it is impossible
+            // at the moment.
+            /*
+             * if (measurement == null) {
+             * throw new NoSuchMeasurementException("Unable to stop service. There was no open measurement to close.");
+             * }
+             */
 
             stopService(measurement, finishedHandler);
         } catch (IllegalArgumentException e) {
@@ -518,8 +521,12 @@ public abstract class DataCapturingService {
      * Deletes a {@link Measurement} from this device.
      *
      * @param measurement The {@link Measurement} to delete.
+     *
+     * @throws NoSuchMeasurementException If the provided measurement was <code>null</code> due to some unknown reasons.
+     *             This is an API violation. You are not supposed to provide <code>null</code> measurements to this
+     *             method.
      */
-    public void deleteMeasurement(final @NonNull Measurement measurement) {
+    public void deleteMeasurement(final @NonNull Measurement measurement) throws NoSuchMeasurementException {
         persistenceLayer.delete(measurement);
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/persistence/MeasurementPersistence.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/persistence/MeasurementPersistence.java
@@ -360,8 +360,14 @@ public class MeasurementPersistence {
      * Removes one {@link Measurement} from the local persistent data storage.
      *
      * @param measurement The measurement to remove.
+     *
+     * @throws NoSuchMeasurementException If the provided measurement was <code>null</code>.
      */
-    public void delete(final @NonNull Measurement measurement) {
+    public void delete(final @NonNull Measurement measurement) throws NoSuchMeasurementException {
+        if(measurement==null) {
+            throw new NoSuchMeasurementException("Unable to delete null measurement!");
+        }
+
         String[] arrayWithMeasurementIdentifier = {Long.valueOf(measurement.getIdentifier()).toString()};
         resolver.delete(getRotationsUri(), RotationPointTable.COLUMN_MEASUREMENT_FK + "=?",
                 arrayWithMeasurementIdentifier);


### PR DESCRIPTION
Actually the @NonNull annotation should tell the user to not do this. But this should make it even clearer if the API was used in a wrong way, as it is at the moment. This exception occurs (like in the last PRs) if one of the old double entrys gets deleted.