### PR TITLE
Fixes the space warning event which was not triggered CY-3740

### DIFF
--- a/datacapturing/src/main/java/de/cyface/datacapturing/DiskConsumption.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DiskConsumption.java
@@ -1,7 +1,9 @@
 package de.cyface.datacapturing;
 
+import static android.content.ContentValues.TAG;
+import static de.cyface.synchronization.Constants.BASE_PATH;
+
 import java.util.Locale;
-import java.util.Objects;
 
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -10,9 +12,6 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import de.cyface.synchronization.Constants;
-
-import static android.content.ContentValues.TAG;
-import static de.cyface.synchronization.Constants.BASE_PATH;
 
 /**
  * Objects of this class represent the current disk (or rather SD card) space used and available. This space is mostly
@@ -110,11 +109,12 @@ public final class DiskConsumption implements Parcelable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DiskConsumption that = (DiskConsumption) o;
-        return consumedBytes == that.consumedBytes &&
-                availableBytes == that.availableBytes;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DiskConsumption that = (DiskConsumption)o;
+        return consumedBytes == that.consumedBytes && availableBytes == that.availableBytes;
     }
 
     @Override

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DiskConsumption.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DiskConsumption.java
@@ -1,6 +1,18 @@
 package de.cyface.datacapturing;
 
 import java.util.Locale;
+import java.util.Objects;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.StatFs;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import de.cyface.synchronization.Constants;
+
+import static android.content.ContentValues.TAG;
+import static de.cyface.synchronization.Constants.BASE_PATH;
 
 /**
  * Objects of this class represent the current disk (or rather SD card) space used and available. This space is mostly
@@ -8,18 +20,19 @@ import java.util.Locale;
  * {@link Measurement}s as soon as they use up too much space.
  *
  * @author Klemens Muthmann
- * @version 1.0.0
+ * @author Armin Schnabel
+ * @version 1.0.1
  * @since 1.0.0
  */
-public final class DiskConsumption {
+public final class DiskConsumption implements Parcelable {
     /**
      * The count of bytes currently used by the {@link DataCapturingService}.
      */
-    private final int consumedBytes;
+    private final long consumedBytes;
     /**
      * The count of bytes still available for the {@link DataCapturingService}.
      */
-    private final int availableBytes;
+    private final long availableBytes;
 
     /**
      * Creates a new completely initialized {@code DiskConsumption} object.
@@ -27,7 +40,7 @@ public final class DiskConsumption {
      * @param consumedBytes The count of bytes currently used by the {@link DataCapturingService}.
      * @param availableBytes The count of bytes still available for the {@link DataCapturingService}.
      */
-    public DiskConsumption(final int consumedBytes, final int availableBytes) {
+    public DiskConsumption(final long consumedBytes, final long availableBytes) {
         if (consumedBytes < 0) {
             throw new IllegalArgumentException(String.format(Locale.US,
                     "Illegal value for consumed bytes. May not be smaller then 0 but was %d", consumedBytes));
@@ -44,14 +57,114 @@ public final class DiskConsumption {
     /**
      * @return The count of bytes currently used by the {@link DataCapturingService}.
      */
-    private int getConsumedBytes() {
+    private long getConsumedBytes() {
         return consumedBytes;
     }
 
     /**
      * @return The count of bytes still available for the {@link DataCapturingService}.
      */
-    private int getAvailableBytes() {
+    private long getAvailableBytes() {
         return availableBytes;
+    }
+
+    /*
+     * MARK: Parcelable Interface
+     */
+
+    /**
+     * Constructor as required by <code>Parcelable</code> implementation.
+     *
+     * @param in A <code>Parcel</code> that is a serialized version of a <code>DiskConsumption</code>.
+     */
+    private DiskConsumption(final @NonNull Parcel in) {
+        consumedBytes = in.readLong();
+        availableBytes = in.readLong();
+    }
+
+    /**
+     * The <code>Parcelable</code> creator as required by the Android Parcelable specification.
+     */
+    public static final Creator<DiskConsumption> CREATOR = new Creator<DiskConsumption>() {
+        @Override
+        public DiskConsumption createFromParcel(final Parcel in) {
+            return new DiskConsumption(in);
+        }
+
+        @Override
+        public DiskConsumption[] newArray(final int size) {
+            return new DiskConsumption[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeLong(consumedBytes);
+        dest.writeLong(availableBytes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DiskConsumption that = (DiskConsumption) o;
+        return consumedBytes == that.consumedBytes &&
+                availableBytes == that.availableBytes;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 0;
+        result = 31 * result + (int)(consumedBytes ^ (consumedBytes >>> 32));
+        result = 31 * result + (int)(availableBytes ^ (availableBytes >>> 32));
+        return result;
+    }
+
+    /**
+     * Checks how much storage is left.
+     *
+     * @return The number of bytes of space available.
+     */
+    public static long bytesAvailable() {
+        final StatFs stat = new StatFs(BASE_PATH);
+        final long bytesAvailable;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            bytesAvailable = stat.getBlockSizeLong() * stat.getAvailableBlocksLong();
+        } else {
+            bytesAvailable = (long)stat.getBlockSize() * (long)stat.getAvailableBlocks();
+        }
+        Log.d(TAG, "Space available: " + (bytesAvailable / (1024 * 1024)) + " MB");
+        return bytesAvailable;
+    }
+
+    /**
+     * Checks the size of the storage.
+     *
+     * @return The number of bytes of storage.
+     */
+    public static long storageSize() {
+        final StatFs stat = new StatFs(BASE_PATH);
+        final long bytesStorage;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            bytesStorage = stat.getBlockSizeLong() * stat.getBlockCountLong();
+        } else {
+            bytesStorage = (long)stat.getBlockSize() * (long)stat.getBlockCount();
+        }
+        Log.d(TAG, "Total disk space: " + (bytesStorage / (1024 * 1024)) + " MB");
+        return bytesStorage;
+    }
+
+    /**
+     * Checks if at last {@code MINIMUM_MEGABYTES_REQUIRED} of space is available.
+     *
+     * @return True if enough space is available.
+     */
+    public static boolean spaceAvailable() {
+        return (bytesAvailable() / (1024 * 1024)) > Constants.MINIMUM_MEGABYTES_REQUIRED;
     }
 }

--- a/synchronization/src/cyface/java/de/cyface/synchronization/Constants.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/Constants.java
@@ -1,11 +1,15 @@
 package de.cyface.synchronization;
 
+import java.io.File;
+
+import android.os.Environment;
+
 /**
  * Final static constants used by multiple classes.
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.2.2
+ * @version 1.2.3
  * @since 2.0.0
  */
 public final class Constants {
@@ -22,10 +26,31 @@ public final class Constants {
     final static int ROTATIONS_UPLOAD_BATCH_SIZE = 2_000;
     final static int DIRECTIONS_UPLOAD_BATCH_SIZE = 2_000;
 
-    // This may be used by all implementing apps, thus, public
+    /**
+     * This may be used by all implementing apps, thus, public
+     */
     public final static String AUTH_TOKEN_TYPE = "de.cyface.auth_token_type";
 
+    /**
+     * The charset used to parse Strings (e.g. for JSON data)
+     */
     public final static String DEFAULT_CHARSET = "UTF-8";
+
+    /**
+     * The disk where data can be stored by the SDK, e.g. image material.
+     */
+    public final static String BASE_PATH = Environment.getExternalStorageDirectory().getPath();
+
+    /**
+     * The path where files can be stored by the SDK, e.g. image material.
+     */
+    public final static String CYFACE_FOLDER_PATH = BASE_PATH + File.separator + "Cyface";
+
+    /**
+     * The minimum space required for capturing. We don't want to use the space full up as this would
+     * slow down the device and could get unusable.
+     */
+    public final static long MINIMUM_MEGABYTES_REQUIRED = 100L;
 
     private Constants() {
         // Nothing to do here.

--- a/synchronization/src/movebis/java/de/cyface/synchronization/Constants.java
+++ b/synchronization/src/movebis/java/de/cyface/synchronization/Constants.java
@@ -1,11 +1,13 @@
 package de.cyface.synchronization;
 
+import android.os.Environment;
+
 /**
  * Final static constants used by multiple classes.
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 1.0.1
  * @since 2.0.0
  */
 public final class Constants {
@@ -16,6 +18,17 @@ public final class Constants {
      */
     public final static String ACCOUNT_TYPE = "de.cyface";
     public final static String AUTH_TOKEN_TYPE = "de.cyface.jwt";
+
+    /**
+     * The disk where data can be stored by the SDK, e.g. image material.
+     */
+    public final static String BASE_PATH = Environment.getExternalStorageDirectory().getPath();
+
+    /**
+     * The minimum space required for capturing. We don't want to use the space full up as this would
+     * slow down the device and could get unusable.
+     */
+    public final static long MINIMUM_MEGABYTES_REQUIRED = 100L;
 
     private Constants() {
         // Nothing to do here.


### PR DESCRIPTION
This small PR just makes sure the space warning event is triggered at all (which was not the case before).
The Strategies we talked about will be implemented separately later to keep the PRs small.