### PR TITLE
Replace capturing stopped global broadcast with local broadcast #CY-4181

### DIFF
--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
@@ -170,7 +170,7 @@ public class BackgroundServiceTest {
             @Override
             public void run() {
                 PongReceiver isRunningChecker = new PongReceiver(context);
-                isRunningChecker.pongAndReceive(2, TimeUnit.SECONDS, testCallback);
+                isRunningChecker.asyncIsRunningCheck(2, TimeUnit.SECONDS, testCallback);
             }
         });
 

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
@@ -39,7 +39,7 @@ import de.cyface.datacapturing.persistence.MeasurementPersistence;
  * GPS signal availability it is a flaky test.
  *
  * @author Klemens Muthmann
- * @version 2.0.4
+ * @version 2.0.5
  * @since 2.0.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
@@ -170,7 +170,7 @@ public class BackgroundServiceTest {
             @Override
             public void run() {
                 PongReceiver isRunningChecker = new PongReceiver(context);
-                isRunningChecker.asyncIsRunningCheck(2, TimeUnit.SECONDS, testCallback);
+                isRunningChecker.checkIsRunningAsync(2, TimeUnit.SECONDS, testCallback);
             }
         });
 

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
@@ -64,7 +64,7 @@ class ToServiceConnection implements ServiceConnection {
         }
 
         PongReceiver isRunningChecker = new PongReceiver(context);
-        isRunningChecker.pongAndReceive(1, TimeUnit.MINUTES, callback);
+        isRunningChecker.asyncIsRunningCheck(1, TimeUnit.MINUTES, callback);
     }
 
     @Override

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
@@ -21,7 +21,7 @@ import static de.cyface.datacapturing.ServiceTestUtils.TAG;
  * Connection from the test to the capturing service.
  *
  * @author Klemens Muthmann
- * @version 1.1.3
+ * @version 1.1.4
  * @since 2.0.0
  */
 class ToServiceConnection implements ServiceConnection {

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
@@ -64,7 +64,7 @@ class ToServiceConnection implements ServiceConnection {
         }
 
         PongReceiver isRunningChecker = new PongReceiver(context);
-        isRunningChecker.asyncIsRunningCheck(1, TimeUnit.MINUTES, callback);
+        isRunningChecker.checkIsRunningAsync(1, TimeUnit.MINUTES, callback);
     }
 
     @Override

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
@@ -117,7 +117,7 @@ public class PingPongTest {
         }
 
         TestCallback testCallback = new TestCallback("testWithRunningService", lock, condition);
-        oocut.asyncIsRunningCheck(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
+        oocut.checkIsRunningAsync(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
 
         lock.lock();
         try {
@@ -151,7 +151,7 @@ public class PingPongTest {
     public void testWithNonRunningService() {
         TestCallback testCallback = new TestCallback("testWithNonRunningService", lock, condition);
 
-        oocut.asyncIsRunningCheck(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
+        oocut.checkIsRunningAsync(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
 
         lock.lock();
         try {

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
@@ -32,7 +32,7 @@ import de.cyface.datacapturing.model.Vehicle;
  * expected.
  *
  * @author Klemens Muthmann
- * @since 2.3.1
+ * @since 2.3.2
  * @version 1.0.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
@@ -117,7 +117,7 @@ public class PingPongTest {
         }
 
         TestCallback testCallback = new TestCallback("testWithRunningService", lock, condition);
-        oocut.pongAndReceive(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
+        oocut.asyncIsRunningCheck(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
 
         lock.lock();
         try {
@@ -151,7 +151,7 @@ public class PingPongTest {
     public void testWithNonRunningService() {
         TestCallback testCallback = new TestCallback("testWithNonRunningService", lock, condition);
 
-        oocut.pongAndReceive(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
+        oocut.asyncIsRunningCheck(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
 
         lock.lock();
         try {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -717,7 +717,6 @@ public abstract class DataCapturingService {
         final Context context = getContext();
         Log.v(TAG, "Registering receiver for service start broadcast.");
         context.registerReceiver(startUpFinishedHandler, new IntentFilter(MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED));
-        LocalBroadcastManager.getInstance(context).unregisterReceiver(startUpFinishedHandler);
         Log.v(TAG, String.format("Starting using Intent with context %s.", context));
         final Intent startIntent = new Intent(context, DataCapturingBackgroundService.class);
         startIntent.putExtra(MEASUREMENT_ID, measurement.getIdentifier());

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -572,7 +572,7 @@ public abstract class DataCapturingService {
     public void isRunning(final long timeout, final TimeUnit unit, final @NonNull IsRunningCallback callback) {
         Log.d(TAG, "Checking isRunning?");
         final PongReceiver pongReceiver = new PongReceiver(getContext());
-        pongReceiver.asyncIsRunningCheck(timeout, unit, callback);
+        pongReceiver.checkIsRunningAsync(timeout, unit, callback);
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -72,7 +72,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.1.5
+ * @version 7.1.6
  * @since 1.0.0
  */
 public abstract class DataCapturingService {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
@@ -1,11 +1,16 @@
 package de.cyface.datacapturing;
 
+import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
+
 /**
- * This class is a wrapper for all message codes used by the Cyface backend to send inter process communication (IPC)
- * messages.
+ * This class is a wrapper for all message codes used by the Cyface backend to send inner- and inter process
+ * communication (IPC) messages. For safety and efficiency we use LocalBroadcasts for inner process communication
+ * as they are very easy to use and {@link android.os.Message}s for inter-process communication as the
+ * LocalBroadcasts can't be passed between processes.
  *
  * @author Klemens Muthmann
- * @version 1.1.1
+ * @author Armin Schnabel
+ * @version 1.2.0
  * @since 2.0.0
  */
 public class MessageCodes {
@@ -53,27 +58,40 @@ public class MessageCodes {
      */
     public static final int SERVICE_STOPPED_ITSELF = 11;
 
-    // TODO This needs to be qualified. We should for example add the application id.
     /**
-     * Broadcast action identifier for ping messages sent to the
-     * {@link de.cyface.datacapturing.backend.DataCapturingBackgroundService}, to check if it is alive.
+     * Global Broadcast (inter-process) action identifier for ping messages sent by the
+     * {@link DataCapturingService}'s {@link PongReceiver} to the
+     * {@link DataCapturingBackgroundService#pingReceiver}, to check if the {@link DataCapturingBackgroundService} is
+     * alive.
+     *
+     * @deprecated because global broadcasts are a security risk and interfere with multiply apps integrating
+     *             out SDK ! FIXME in CY-3575 !
      */
-    public static final String ACTION_PING = "de.cyface.ping";
+    public static final String GLOBAL_BROADCAST_PING = "de.cyface.ping";
     /**
-     * Broadcast action identifier for pong messages sent from the
-     * {@link de.cyface.datacapturing.backend.DataCapturingBackgroundService} as answer to a received ping.
+     * Global Broadcast (inter-process) action identifier for pong messages sent by the
+     * {@link DataCapturingBackgroundService#pingReceiver} as answer to a received ping.
+     *
+     *
+     * @deprecated because global broadcasts are a security risk and interfere with multiply apps integrating
+     *             out SDK ! FIXME in CY-3575 !
      */
-    public static final String ACTION_PONG = "de.cyface.pong";
+    public static final String GLOBAL_BROADCAST_PONG = "de.cyface.pong";
     /**
-     * Broadcast action identifier sent by the {@link de.cyface.datacapturing.backend.DataCapturingBackgroundService}
-     * after it has successfully started.
+     * Global Broadcast action identifier sent by the {@link DataCapturingBackgroundService} to the
+     * {@link DataCapturingService}'s {@link StartUpFinishedHandler} after it
+     * has successfully started.
+     * 
+     * @deprecated because global broadcasts are a security risk and interfere with multiply apps integrating
+     *             out SDK ! FIXME in CY-3575 !
      */
-    public static final String BROADCAST_SERVICE_STARTED = "de.cyface.service_started";
+    public static final String GLOBAL_BROADCAST_SERVICE_STARTED = "de.cyface.service_started";
     /**
-     * Broadcast action identifier sent by the {@link de.cyface.datacapturing.backend.DataCapturingBackgroundService}
-     * after it has successfully stopped.
+     * Local (i.e. inner process communication) Broadcast action identifier sent by the {@link DataCapturingService}
+     * after it has received a inter-process {@link MessageCodes#SERVICE_STOPPED} from the
+     * {@link DataCapturingBackgroundService} that it has successfully stopped.
      */
-    public static final String FINISHED_HANDLER_BROADCAST_SERVICE_STOPPED = "de.cyface.service_stopped";
+    public static final String LOCAL_BROADCAST_SERVICE_STOPPED = "de.cyface.service_stopped";
 
     /**
      * Private constructor for utility class.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
@@ -4,9 +4,7 @@ import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
 
 /**
  * This class is a wrapper for all message codes used by the Cyface backend to send inner- and inter process
- * communication (IPC) messages. For safety and efficiency we use LocalBroadcasts for inner process communication
- * as they are very easy to use and {@link android.os.Message}s for inter-process communication as the
- * LocalBroadcasts can't be passed between processes.
+ * communication (IPC) messages.
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel

--- a/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
@@ -10,7 +10,7 @@ import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.2.0
+ * @version 1.1.2
  * @since 2.0.0
  */
 public class MessageCodes {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -89,7 +89,7 @@ public class PongReceiver extends BroadcastReceiver {
      * @param callback The callback to inform about either the timeout or the successful reception of the
      *            <code>MessageCodes.PONG</code> message.
      */
-    public void asyncIsRunningCheck(final long timeout, final @NonNull TimeUnit unit,
+    public void checkIsRunningAsync(final long timeout, final @NonNull TimeUnit unit,
                                     final @NonNull IsRunningCallback callback) {
         this.callback = callback;
 
@@ -103,20 +103,20 @@ public class PongReceiver extends BroadcastReceiver {
         long offset = unit.toMillis(timeout);
 
         final String pingPongIdentifier = UUID.randomUUID().toString();
-        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Variable currentUptimeInMillis is " + currentUptimeInMillis);
-        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Variable offset is " + offset);
-        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Sending ping with identifier " + pingPongIdentifier);
+        Log.v(TAG, "PongReceiver.checkIsRunningAsync(): Variable currentUptimeInMillis is " + currentUptimeInMillis);
+        Log.v(TAG, "PongReceiver.checkIsRunningAsync(): Variable offset is " + offset);
+        Log.v(TAG, "PongReceiver.checkIsRunningAsync(): Sending ping with identifier " + pingPongIdentifier);
 
         Handler timeoutHandler = new Handler(pongReceiverThread.getLooper());
         timeoutHandler.postAtTime(new Runnable() {
             @Override
             public void run() {
-                Log.d(TAG, "PongReceiver.asyncIsRunningCheck(): Timeout for pong " + pingPongIdentifier + " reached after "
+                Log.d(TAG, "PongReceiver.checkIsRunningAsync(): Timeout for pong " + pingPongIdentifier + " reached after "
                         + unit.toMillis(timeout) + " milliseconds. Executed at: " + SystemClock.uptimeMillis());
                 lock.lock();
                 try {
                     if (!isRunning) {
-                        Log.d(TAG, "PongReceiver.asyncIsRunningCheck(): Service seems not to be running. Timing out!");
+                        Log.d(TAG, "PongReceiver.checkIsRunningAsync(): Service seems not to be running. Timing out!");
                         PongReceiver.this.callback.timedOut();
                         isTimedOut = true;
                         context.unregisterReceiver(PongReceiver.this);
@@ -133,7 +133,7 @@ public class PongReceiver extends BroadcastReceiver {
             broadcastIntent.putExtra(BundlesExtrasCodes.PING_PONG_ID, pingPongIdentifier);
         }
         context.sendBroadcast(broadcastIntent);
-        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Ping was sent!");
+        Log.v(TAG, "PongReceiver.checkIsRunningAsync(): Ping was sent!");
     }
 
     @Override

--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -89,38 +89,34 @@ public class PongReceiver extends BroadcastReceiver {
      * @param callback The callback to inform about either the timeout or the successful reception of the
      *            <code>MessageCodes.PONG</code> message.
      */
-    public void pongAndReceive(final long timeout, final @NonNull TimeUnit unit,
-            final @NonNull IsRunningCallback callback) {
+    public void asyncIsRunningCheck(final long timeout, final @NonNull TimeUnit unit,
+                                    final @NonNull IsRunningCallback callback) {
         this.callback = callback;
 
         // Run receiver on a different thread so it runs even if calling thread waits for it to return:
 
         pongReceiverThread.start();
         Handler receiverHandler = new Handler(pongReceiverThread.getLooper());
-        context.registerReceiver(this, new IntentFilter(MessageCodes.ACTION_PONG), null, receiverHandler);
+        context.registerReceiver(this, new IntentFilter(MessageCodes.GLOBAL_BROADCAST_PONG), null, receiverHandler);
 
         long currentUptimeInMillis = SystemClock.uptimeMillis();
         long offset = unit.toMillis(timeout);
 
-        Intent broadcastIntent = new Intent(MessageCodes.ACTION_PING);
         final String pingPongIdentifier = UUID.randomUUID().toString();
-        if (BuildConfig.DEBUG) {
-            broadcastIntent.putExtra(BundlesExtrasCodes.PING_PONG_ID, pingPongIdentifier);
-        }
-        Log.v(TAG, "PongReceiver.pongAndReceive(): Variable currentUptimeInMillis is " + currentUptimeInMillis);
-        Log.v(TAG, "PongReceiver.pongAndReceive(): Variable offset is " + offset);
-        Log.v(TAG, "PongReceiver.pongAndReceive(): Sending ping with identifier " + pingPongIdentifier);
+        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Variable currentUptimeInMillis is " + currentUptimeInMillis);
+        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Variable offset is " + offset);
+        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Sending ping with identifier " + pingPongIdentifier);
 
         Handler timeoutHandler = new Handler(pongReceiverThread.getLooper());
         timeoutHandler.postAtTime(new Runnable() {
             @Override
             public void run() {
-                Log.d(TAG, "PongReceiver.pongAndReceive(): Timeout for pong " + pingPongIdentifier + " reached after "
+                Log.d(TAG, "PongReceiver.asyncIsRunningCheck(): Timeout for pong " + pingPongIdentifier + " reached after "
                         + unit.toMillis(timeout) + " milliseconds. Executed at: " + SystemClock.uptimeMillis());
                 lock.lock();
                 try {
                     if (!isRunning) {
-                        Log.d(TAG, "PongReceiver.pongAndReceive(): Service seems not to be running. Timing out!");
+                        Log.d(TAG, "PongReceiver.asyncIsRunningCheck(): Service seems not to be running. Timing out!");
                         PongReceiver.this.callback.timedOut();
                         isTimedOut = true;
                         context.unregisterReceiver(PongReceiver.this);
@@ -132,8 +128,12 @@ public class PongReceiver extends BroadcastReceiver {
             }
         }, currentUptimeInMillis + offset);
 
+        final Intent broadcastIntent = new Intent(MessageCodes.GLOBAL_BROADCAST_PING);
+        if (BuildConfig.DEBUG) {
+            broadcastIntent.putExtra(BundlesExtrasCodes.PING_PONG_ID, pingPongIdentifier);
+        }
         context.sendBroadcast(broadcastIntent);
-        Log.v(TAG, "PongReceiver.pongAndReceive(): Ping was sent!");
+        Log.v(TAG, "PongReceiver.asyncIsRunningCheck(): Ping was sent!");
     }
 
     @Override
@@ -142,7 +142,7 @@ public class PongReceiver extends BroadcastReceiver {
                 + intent.getStringExtra(BundlesExtrasCodes.PING_PONG_ID));
         lock.lock();
         try {
-            if (!isTimedOut && MessageCodes.ACTION_PONG.equals(intent.getAction())) {
+            if (!isTimedOut && MessageCodes.GLOBAL_BROADCAST_PONG.equals(intent.getAction())) {
                 Log.d(TAG, "PongReceiver.onReceive(): Timeout was not reached. Service seems to be active.");
                 isRunning = true;
                 callback.isRunning();

--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -25,7 +25,7 @@ import android.util.Log;
  * tell the caller, that the service is not running.
  *
  * @author Klemens Muthmann
- * @version 1.1.3
+ * @version 1.1.4
  * @since 2.0.0
  */
 public class PongReceiver extends BroadcastReceiver {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/ShutDownFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/ShutDownFinishedHandler.java
@@ -19,7 +19,7 @@ import android.util.Log;
  * To work properly you must register this object as an Android <code>BroadcastReceiver</code>.
  *
  * @author Klemens Muthmann
- * @version 2.0.2
+ * @version 2.0.3
  * @since 2.0.0
  * @see DataCapturingService#pauseAsync(ShutDownFinishedHandler)
  * @see DataCapturingService#stopAsync(ShutDownFinishedHandler)

--- a/datacapturing/src/main/java/de/cyface/datacapturing/ShutDownFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/ShutDownFinishedHandler.java
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 /**
@@ -26,7 +27,7 @@ import android.util.Log;
 public abstract class ShutDownFinishedHandler extends BroadcastReceiver {
 
     /**
-     * This is set to <code>true</code> if either a <code>MessageCodes.FINISHED_HANDLER_BROADCAST_SERVICE_STOPPED</code> broadcast has
+     * This is set to <code>true</code> if either a <code>MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED</code> broadcast has
      * been received or a <code>MessageCodes.SERVICE_STOPPED</code> was issued. It is <code>false</code> otherwise.
      */
     private boolean receivedServiceStopped;
@@ -46,7 +47,7 @@ public abstract class ShutDownFinishedHandler extends BroadcastReceiver {
             throw new IllegalStateException("Received broadcast with null action.");
         }
         switch (intent.getAction()) {
-            case MessageCodes.FINISHED_HANDLER_BROADCAST_SERVICE_STOPPED:
+            case MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED:
                 Log.v(TAG, "Received Service stopped broadcast!");
                 receivedServiceStopped = true;
                 boolean serviceWasStoppedSuccessfully = intent.getBooleanExtra(STOPPED_SUCCESSFULLY, false);
@@ -64,7 +65,7 @@ public abstract class ShutDownFinishedHandler extends BroadcastReceiver {
         }
 
         try {
-            context.unregisterReceiver(this);
+            LocalBroadcastManager.getInstance(context).unregisterReceiver(this);
         } catch (IllegalArgumentException e) {
             Log.w(TAG, "Probably tried to deregister shut down finished broadcast receiver twice.", e);
         }
@@ -72,7 +73,7 @@ public abstract class ShutDownFinishedHandler extends BroadcastReceiver {
     }
 
     /**
-     * @return This is set to <code>true</code> if either a <code>MessageCodes.FINISHED_HANDLER_BROADCAST_SERVICE_STOPPED</code>
+     * @return This is set to <code>true</code> if either a <code>MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED</code>
      *         broadcast has
      *         been received or a <code>MessageCodes.SERVICE_STOPPED</code> was issued. It is <code>false</code>
      *         otherwise.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
@@ -20,7 +20,7 @@ import de.cyface.datacapturing.model.Vehicle;
  * To work properly you must register this object as an Android <code>BroadcastReceiver</code>..
  *
  * @author Klemens Muthmann
- * @version 2.0.2
+ * @version 2.0.3
  * @since 2.0.0
  * @see DataCapturingService#resumeAsync(StartUpFinishedHandler)
  * @see DataCapturingService#startAsync(DataCapturingListener, Vehicle, StartUpFinishedHandler)

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import de.cyface.datacapturing.model.Vehicle;
@@ -27,7 +28,7 @@ import de.cyface.datacapturing.model.Vehicle;
 public abstract class StartUpFinishedHandler extends BroadcastReceiver {
 
     /**
-     * This is set to <code>true</code> if a <code>MessageCodes.BROADCAST_SERVICE_STARTED</code> broadcast has been
+     * This is set to <code>true</code> if a <code>MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED</code> broadcast has been
      * received and is <code>false</code> otherwise.
      */
     private boolean receivedServiceStarted;
@@ -46,7 +47,7 @@ public abstract class StartUpFinishedHandler extends BroadcastReceiver {
             throw new IllegalStateException("Received broadcast with null action.");
         }
         switch (intent.getAction()) {
-            case MessageCodes.BROADCAST_SERVICE_STARTED:
+            case MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED:
                 Log.v(TAG, "Received Service started broadcast!");
                 receivedServiceStarted = true;
                 long measurementIdentifier = intent.getLongExtra(MEASUREMENT_ID, -1L);
@@ -66,7 +67,7 @@ public abstract class StartUpFinishedHandler extends BroadcastReceiver {
     }
 
     /**
-     * @return This is set to <code>true</code> if a <code>MessageCodes.BROADCAST_SERVICE_STARTED</code> broadcast has
+     * @return This is set to <code>true</code> if a <code>MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED</code> broadcast has
      *         been
      *         received and is <code>false</code> otherwise.
      */

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -6,7 +6,7 @@ import static de.cyface.datacapturing.BundlesExtrasCodes.MEASUREMENT_ID;
 import static de.cyface.datacapturing.BundlesExtrasCodes.STOPPED_SUCCESSFULLY;
 import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
 import static de.cyface.datacapturing.DiskConsumption.spaceAvailable;
-import static de.cyface.datacapturing.MessageCodes.ACTION_PING;
+import static de.cyface.datacapturing.MessageCodes.GLOBAL_BROADCAST_PING;
 import static de.cyface.datacapturing.ui.CapturingNotification.CAPTURING_NOTIFICATION_ID;
 
 import java.lang.ref.WeakReference;
@@ -172,7 +172,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
 
         // Allows other parties to ping this service to see if it is running
         Log.v(TAG, "Registering Ping Receiver");
-        registerReceiver(pingReceiver, new IntentFilter(ACTION_PING));
+        registerReceiver(pingReceiver, new IntentFilter(GLOBAL_BROADCAST_PING));
         Log.d(TAG, "finishedOnCreate");
     }
 
@@ -258,7 +258,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
 
         // Informs about the service start
         Log.v(TAG, "Sending broadcast service started.");
-        final Intent serviceStartedIntent = new Intent(MessageCodes.BROADCAST_SERVICE_STARTED);
+        final Intent serviceStartedIntent = new Intent(MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED);
         serviceStartedIntent.putExtra(MEASUREMENT_ID, currentMeasurementIdentifier);
         sendBroadcast(serviceStartedIntent);
         return Service.START_STICKY;

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -56,7 +56,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.12
+ * @version 4.0.13
  * @since 2.0.0
  */
 public class DataCapturingBackgroundService extends Service implements CapturingProcessListener {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
@@ -1,8 +1,8 @@
 package de.cyface.datacapturing.backend;
 
 import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
-import static de.cyface.datacapturing.MessageCodes.ACTION_PING;
-import static de.cyface.datacapturing.MessageCodes.ACTION_PONG;
+import static de.cyface.datacapturing.MessageCodes.GLOBAL_BROADCAST_PING;
+import static de.cyface.datacapturing.MessageCodes.GLOBAL_BROADCAST_PONG;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -32,8 +32,8 @@ public class PingReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(final @NonNull Context context, final @NonNull Intent intent) {
         Validate.notNull(intent.getAction());
-        if (intent.getAction().equals(ACTION_PING)) {
-            Intent pongIntent = new Intent(ACTION_PONG);
+        if (intent.getAction().equals(GLOBAL_BROADCAST_PING)) {
+            Intent pongIntent = new Intent(GLOBAL_BROADCAST_PONG);
             if (BuildConfig.DEBUG) {
                 String pingPongIdentifier = intent.getStringExtra(BundlesExtrasCodes.PING_PONG_ID);
                 Log.d(TAG, "PingReceiver.onReceive(): Received Ping with identifier " + pingPongIdentifier

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
@@ -19,7 +19,7 @@ import de.cyface.utils.Validate;
  * This can be used to check if the service is alive.
  *
  * @author Klemens Muthmann
- * @version 1.0.3
+ * @version 1.0.4
  * @since 2.0.0
  */
 public class PingReceiver extends BroadcastReceiver {


### PR DESCRIPTION
Only the CAPTURING_STOPPED global broadcast was replaced by a local broadcast as the other global broadcasts are inter-process communication and, thus, don't work with local broadcasts (tested).

But I added the task number and deprecated tag to those broadcasts and some docu.

Most of the code changes are renamings and docu, the only functional difference is that the STOPPED broadcast is now locally un-/register/sent