### PR TITLE
Bug/cy 3575 sdk integrating apps not independent

### DIFF
--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingListener.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingListener.java
@@ -3,15 +3,17 @@ package de.cyface.datacapturing;
 import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
 import de.cyface.datacapturing.model.CapturedData;
 import de.cyface.datacapturing.model.GeoLocation;
+import de.cyface.datacapturing.model.Vehicle;
 import de.cyface.datacapturing.ui.Reason;
 
 /**
  * An interface for a listener, listening for data capturing events. This listener can be registered with a
  * {@link DataCapturingService} via
- * {@link DataCapturingService#startSync(DataCapturingListener,de.cyface.datacapturing.model.Vehicle)}.
+ * {@link DataCapturingService#startSync(DataCapturingListener, Vehicle)}.
  *
  * @author Klemens Muthmann
- * @version 1.2.1
+ * @author Armin Schnabel
+ * @version 1.3.0
  * @since 1.0.0
  */
 public interface DataCapturingListener {
@@ -75,4 +77,11 @@ public interface DataCapturingListener {
      * was implemented which stops the {@link DataCapturingBackgroundService} when the space is low.
      */
     void onCapturingStopped();
+
+    /**
+     * This method is called when the capturing started.
+     *
+     * @param measurementIdentifier The id of the started measurement
+     */
+    void onCapturingStarted(long measurementIdentifier);
 }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -1007,7 +1007,7 @@ public abstract class DataCapturingService {
      *
      * @param listener A listener that is notified of important events during synchronization.
      */
-    public void removeConnectionListener(final @NonNull ConnectionStatusListener listener) {
+    public void removeConnectionStatusListener(final @NonNull ConnectionStatusListener listener) {
         this.connectionStatusReceiver.removeListener(listener);
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -678,7 +678,7 @@ public abstract class DataCapturingService {
             throws DataCapturingException {
         Lock lock = new ReentrantLock();
         Condition condition = lock.newCondition();
-        StartSynchronizer synchronizationReceiver = new StartSynchronizer(lock, condition);
+        StartSynchronizer synchronizationReceiver = new StartSynchronizer(lock, condition, fromServiceMessageHandler);
         runService(measurement, synchronizationReceiver);
 
         lock.lock();
@@ -696,9 +696,9 @@ public abstract class DataCapturingService {
         } finally {
             lock.unlock();
             try {
-                //getContext().unregisterReceiver(synchronizationReceiver); FIXME
+                fromServiceMessageHandler.removeListener(synchronizationReceiver);
             } catch (IllegalArgumentException e) {
-                Log.w(TAG, "Probably tried to deregister start up finished broadcast receiver twice.", e);
+                Log.w(TAG, "Probably tried to remove start up finished listener twice.", e);
             }
         }
     }
@@ -1075,7 +1075,7 @@ public abstract class DataCapturingService {
      * @version 1.0.0
      * @since 2.0.0
      */
-    private static class FromServiceMessageHandler extends Handler {
+    public static class FromServiceMessageHandler extends Handler {
 
         /**
          * A listener that is notified of important events during data capturing.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
@@ -1,8 +1,12 @@
 package de.cyface.datacapturing;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Message;
+import android.preference.PreferenceManager;
 
 import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
+import de.cyface.synchronization.SyncService;
 
 /**
  * This class is a wrapper for all message codes used by the Cyface backend to send inner- and inter process
@@ -10,7 +14,7 @@ import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.1.2
+ * @version 1.1.3
  * @since 2.0.0
  */
 public class MessageCodes {
@@ -67,36 +71,42 @@ public class MessageCodes {
      * Global Broadcast (inter-process) action identifier for ping messages sent by the
      * {@link DataCapturingService}'s {@link PongReceiver} to the
      * {@link DataCapturingBackgroundService#pingReceiver}, to check if the {@link DataCapturingBackgroundService} is
-     * alive.
-     *
-     * @deprecated because global broadcasts are a security risk and interfere with multiply apps integrating
-     *             out SDK ! FIXME in CY-3575 !
+     * alive. TODO use a message handler instead #CY-4091
      */
-    public static final String GLOBAL_BROADCAST_PING = "de.cyface.ping";
+    private static final String GLOBAL_BROADCAST_PING = "de.cyface.ping";
     /**
      * Global Broadcast (inter-process) action identifier for pong messages sent by the
      * {@link DataCapturingBackgroundService#pingReceiver} as answer to a received ping.
-     *
-     *
-     * @deprecated because global broadcasts are a security risk and interfere with multiply apps integrating
-     *             out SDK ! FIXME in CY-3575 !
+     * TODO use a message handler instead #CY-4091
      */
-    public static final String GLOBAL_BROADCAST_PONG = "de.cyface.pong";
+    private static final String GLOBAL_BROADCAST_PONG = "de.cyface.pong";
+
     /**
-     * Global Broadcast action identifier sent by the {@link DataCapturingBackgroundService} to the
-     * {@link DataCapturingService}'s {@link StartUpFinishedHandler} after it
-     * has successfully started.
-     * 
-     * @deprecated because global broadcasts are a security risk and interfere with multiply apps integrating
-     *             out SDK ! FIXME in CY-3575 !
+     * To avoid collision between sdk integrating apps use the app unique device id as prefix when using
+     * this a action identifier for global broadcasts (for inter process communication)
      */
-    public static final String GLOBAL_BROADCAST_SERVICE_STARTED = "de.cyface.service_started";
+    public static String getGlobalBroadcastPing(final Context context) {
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String deviceIdentifier = preferences.getString(SyncService.DEVICE_IDENTIFIER_KEY, null);
+        return deviceIdentifier + "_" + GLOBAL_BROADCAST_PING;
+    }
+
+    /**
+     * To avoid collision between sdk integrating apps use the app unique device id as prefix when using
+     * this a action identifier for global broadcasts (for inter process communication)
+     */
+    public static String getGlobalBroadcastPong(final Context context) {
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String deviceIdentifier = preferences.getString(SyncService.DEVICE_IDENTIFIER_KEY, null);
+        return deviceIdentifier + "_" + GLOBAL_BROADCAST_PONG;
+    }
+
     /**
      * Local (i.e. inner process communication) Broadcast action identifier sent by the {@link DataCapturingService}
      * after it has received a inter-process {@link MessageCodes#SERVICE_STOPPED} from the
      * {@link DataCapturingBackgroundService} that it has successfully stopped.
      */
-    public static final String LOCAL_BROADCAST_SERVICE_STOPPED = "de.cyface.service_stopped";
+    static final String LOCAL_BROADCAST_SERVICE_STOPPED = "de.cyface.service_stopped";
 
     /**
      * Private constructor for utility class.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
@@ -1,5 +1,7 @@
 package de.cyface.datacapturing;
 
+import android.os.Message;
+
 import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
 
 /**
@@ -55,6 +57,11 @@ public class MessageCodes {
      * when it notices that only little space is left.
      */
     public static final int SERVICE_STOPPED_ITSELF = 11;
+    /**
+     * The code for inter-process {@link Message}s sent from the {@link DataCapturingBackgroundService} to the
+     * {@link DataCapturingService} when the background service started.
+     */
+    public static final int SERVICE_STARTED = 12;
 
     /**
      * Global Broadcast (inter-process) action identifier for ping messages sent by the

--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -11,13 +11,17 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Process;
 import android.os.SystemClock;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.util.Log;
+
+import de.cyface.synchronization.SyncService;
 
 /**
  * A <code>BroadcastReceiver</code> and sender that send a <code>MessageCodes.PING</code> event to the system and
@@ -25,7 +29,7 @@ import android.util.Log;
  * tell the caller, that the service is not running.
  *
  * @author Klemens Muthmann
- * @version 1.1.4
+ * @version 1.1.7
  * @since 2.0.0
  */
 public class PongReceiver extends BroadcastReceiver {
@@ -97,7 +101,7 @@ public class PongReceiver extends BroadcastReceiver {
 
         pongReceiverThread.start();
         Handler receiverHandler = new Handler(pongReceiverThread.getLooper());
-        context.registerReceiver(this, new IntentFilter(MessageCodes.GLOBAL_BROADCAST_PONG), null, receiverHandler);
+        context.registerReceiver(this, new IntentFilter(MessageCodes.getGlobalBroadcastPong(context)), null, receiverHandler);
 
         long currentUptimeInMillis = SystemClock.uptimeMillis();
         long offset = unit.toMillis(timeout);
@@ -128,7 +132,7 @@ public class PongReceiver extends BroadcastReceiver {
             }
         }, currentUptimeInMillis + offset);
 
-        final Intent broadcastIntent = new Intent(MessageCodes.GLOBAL_BROADCAST_PING);
+        final Intent broadcastIntent = new Intent(MessageCodes.getGlobalBroadcastPing(context));
         if (BuildConfig.DEBUG) {
             broadcastIntent.putExtra(BundlesExtrasCodes.PING_PONG_ID, pingPongIdentifier);
         }
@@ -142,7 +146,7 @@ public class PongReceiver extends BroadcastReceiver {
                 + intent.getStringExtra(BundlesExtrasCodes.PING_PONG_ID));
         lock.lock();
         try {
-            if (!isTimedOut && MessageCodes.GLOBAL_BROADCAST_PONG.equals(intent.getAction())) {
+            if (!isTimedOut && MessageCodes.getGlobalBroadcastPong(context).equals(intent.getAction())) {
                 Log.d(TAG, "PongReceiver.onReceive(): Timeout was not reached. Service seems to be active.");
                 isRunning = true;
                 callback.isRunning();

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartSynchronizer.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartSynchronizer.java
@@ -28,7 +28,8 @@ public class StartSynchronizer extends StartUpFinishedHandler {
      * @param lock The lock used for synchronization. Usually a <code>ReentrantLock</code>.
      * @param condition The condition waiting for a signal from this <code>StartSynchronizer</code>.
      */
-    public StartSynchronizer(final @NonNull Lock lock, final @NonNull Condition condition) {
+    public StartSynchronizer(final @NonNull Lock lock, final @NonNull Condition condition, final DataCapturingService.FromServiceMessageHandler fromServiceMessageHandler) {
+        super(fromServiceMessageHandler);
         synchronizer = new Synchronizer(lock, condition);
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
@@ -35,6 +35,8 @@ public abstract class StartUpFinishedHandler implements DataCapturingListener {
      */
     private boolean receivedServiceStarted;
 
+    private DataCapturingService.FromServiceMessageHandler fromServiceMessageHandler;
+
     /**
      * Method called if start up has been finished.
      *
@@ -42,15 +44,22 @@ public abstract class StartUpFinishedHandler implements DataCapturingListener {
      */
     public abstract void startUpFinished(final long measurementIdentifier);
 
+    public StartUpFinishedHandler(final DataCapturingService.FromServiceMessageHandler fromServiceMessageHandler) {
+        this.fromServiceMessageHandler = fromServiceMessageHandler;
+    }
+
     @Override
     public void onCapturingStarted(final long measurementIdentifier) {
         Log.v(TAG, "Received Service started message, mid: " + measurementIdentifier);
         receivedServiceStarted = true;
         startUpFinished(measurementIdentifier);
         try {
-            //unregisterReceiver(this); FIXME
+            // This is only required until we throw out the sync start methods
+            if (fromServiceMessageHandler != null) {
+                fromServiceMessageHandler.removeListener(this);
+            }
         } catch (IllegalArgumentException e) {
-            Log.w(TAG, "Probably tried to deregister start up finished broadcast receiver twice.", e);
+            Log.w(TAG, "Probably tried to remove start up finished listener twice.", e);
         }
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
@@ -3,14 +3,15 @@ package de.cyface.datacapturing;
 import static de.cyface.datacapturing.BundlesExtrasCodes.MEASUREMENT_ID;
 import static de.cyface.datacapturing.Constants.TAG;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
+import de.cyface.datacapturing.model.CapturedData;
+import de.cyface.datacapturing.model.GeoLocation;
 import de.cyface.datacapturing.model.Vehicle;
+import de.cyface.datacapturing.ui.Reason;
 
 /**
  * Handler for start up finished events. Just implement the {@link #startUpFinished(long)} method with the code you
@@ -20,16 +21,17 @@ import de.cyface.datacapturing.model.Vehicle;
  * To work properly you must register this object as an Android <code>BroadcastReceiver</code>..
  *
  * @author Klemens Muthmann
- * @version 2.0.3
+ * @author Armin Schnabel
+ * @version 2.1.0
  * @since 2.0.0
  * @see DataCapturingService#resumeAsync(StartUpFinishedHandler)
  * @see DataCapturingService#startAsync(DataCapturingListener, Vehicle, StartUpFinishedHandler)
  */
-public abstract class StartUpFinishedHandler extends BroadcastReceiver {
+public abstract class StartUpFinishedHandler implements DataCapturingListener {
 
     /**
-     * This is set to <code>true</code> if a <code>MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED</code> broadcast has been
-     * received and is <code>false</code> otherwise.
+     * This is set to <code>true</code> if a <code>MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED</code> broadcast has
+     * been received and is <code>false</code> otherwise.
      */
     private boolean receivedServiceStarted;
 
@@ -41,37 +43,67 @@ public abstract class StartUpFinishedHandler extends BroadcastReceiver {
     public abstract void startUpFinished(final long measurementIdentifier);
 
     @Override
-    public void onReceive(final @NonNull Context context, final @NonNull Intent intent) {
-        Log.v(TAG, "Start/Stop Synchronizer received an intent with action " + intent.getAction() + ".");
-        if (intent.getAction() == null) {
-            throw new IllegalStateException("Received broadcast with null action.");
-        }
-        switch (intent.getAction()) {
-            case MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED:
-                Log.v(TAG, "Received Service started broadcast!");
-                receivedServiceStarted = true;
-                long measurementIdentifier = intent.getLongExtra(MEASUREMENT_ID, -1L);
-                if (measurementIdentifier == -1) {
-                    throw new IllegalStateException("No measurement identifier provided on service started message.");
-                }
-                startUpFinished(measurementIdentifier);
-                break;
-            default:
-                throw new IllegalStateException("Received undefined broadcast " + intent.getAction());
-        }
+    public void onCapturingStarted(final long measurementIdentifier) {
+        Log.v(TAG, "Received Service started message, mid: " + measurementIdentifier);
+        receivedServiceStarted = true;
+        startUpFinished(measurementIdentifier);
         try {
-            context.unregisterReceiver(this);
+            //unregisterReceiver(this); FIXME
         } catch (IllegalArgumentException e) {
             Log.w(TAG, "Probably tried to deregister start up finished broadcast receiver twice.", e);
         }
     }
 
     /**
-     * @return This is set to <code>true</code> if a <code>MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED</code> broadcast has
-     *         been
-     *         received and is <code>false</code> otherwise.
+     * @return This is set to <code>true</code> if a <code>MessageCodes.GLOBAL_BROADCAST_SERVICE_STARTED</code>
+     *         broadcast has been received and is <code>false</code> otherwise.
      */
     public boolean receivedServiceStarted() {
         return receivedServiceStarted;
+    }
+
+    @Override
+    public void onFixAcquired() {
+        // Nothing to do
+    }
+
+    @Override
+    public void onFixLost() {
+        // Nothing to do
+    }
+
+    @Override
+    public void onNewGeoLocationAcquired(GeoLocation position) {
+        // Nothing to do
+    }
+
+    @Override
+    public void onNewSensorDataAcquired(CapturedData data) {
+        // Nothing to do
+    }
+
+    @Override
+    public void onLowDiskSpace(DiskConsumption allocation) {
+        // Nothing to do
+    }
+
+    @Override
+    public void onSynchronizationSuccessful() {
+        // Nothing to do
+    }
+
+    @Override
+    public void onErrorState(Exception e) {
+        // Nothing to do
+    }
+
+    @Override
+    public boolean onRequiresPermission(String permission, Reason reason) {
+        return false; // Nothing to do
+    }
+
+    @Override
+    public void onCapturingStopped() {
+        // Nothing to do
     }
 }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -6,7 +6,6 @@ import static de.cyface.datacapturing.BundlesExtrasCodes.MEASUREMENT_ID;
 import static de.cyface.datacapturing.BundlesExtrasCodes.STOPPED_SUCCESSFULLY;
 import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
 import static de.cyface.datacapturing.DiskConsumption.spaceAvailable;
-import static de.cyface.datacapturing.MessageCodes.GLOBAL_BROADCAST_PING;
 import static de.cyface.datacapturing.ui.CapturingNotification.CAPTURING_NOTIFICATION_ID;
 
 import java.lang.ref.WeakReference;
@@ -56,7 +55,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.13
+ * @version 4.0.14
  * @since 2.0.0
  */
 public class DataCapturingBackgroundService extends Service implements CapturingProcessListener {
@@ -178,7 +177,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
 
         // Allows other parties to ping this service to see if it is running
         Log.v(TAG, "Registering Ping Receiver");
-        registerReceiver(pingReceiver, new IntentFilter(GLOBAL_BROADCAST_PING));
+        registerReceiver(pingReceiver, new IntentFilter(MessageCodes.getGlobalBroadcastPing(getApplicationContext())));
         Log.d(TAG, "finishedOnCreate");
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
@@ -1,8 +1,6 @@
 package de.cyface.datacapturing.backend;
 
 import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
-import static de.cyface.datacapturing.MessageCodes.GLOBAL_BROADCAST_PING;
-import static de.cyface.datacapturing.MessageCodes.GLOBAL_BROADCAST_PONG;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -12,6 +10,7 @@ import android.util.Log;
 
 import de.cyface.datacapturing.BuildConfig;
 import de.cyface.datacapturing.BundlesExtrasCodes;
+import de.cyface.datacapturing.MessageCodes;
 import de.cyface.utils.Validate;
 
 /**
@@ -19,7 +18,7 @@ import de.cyface.utils.Validate;
  * This can be used to check if the service is alive.
  *
  * @author Klemens Muthmann
- * @version 1.0.4
+ * @version 1.0.6
  * @since 2.0.0
  */
 public class PingReceiver extends BroadcastReceiver {
@@ -32,8 +31,8 @@ public class PingReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(final @NonNull Context context, final @NonNull Intent intent) {
         Validate.notNull(intent.getAction());
-        if (intent.getAction().equals(GLOBAL_BROADCAST_PING)) {
-            Intent pongIntent = new Intent(GLOBAL_BROADCAST_PONG);
+        if (intent.getAction().equals(MessageCodes.getGlobalBroadcastPing(context))) {
+            Intent pongIntent = new Intent(MessageCodes.getGlobalBroadcastPong(context));
             if (BuildConfig.DEBUG) {
                 String pingPongIdentifier = intent.getStringExtra(BundlesExtrasCodes.PING_PONG_ID);
                 Log.d(TAG, "PingReceiver.onReceive(): Received Ping with identifier " + pingPongIdentifier


### PR DESCRIPTION
The capturing started IPC is now implemented as message.

The ping pong communication still as global broadcast as
- a IPC cannot work with a local broadcast
- using messages failed in task #CY-4091 see bug #CY-4188, thus, to close this milestone we use the app unique device id as prefix for ping pong broadcasts to avoid collision between sdk integrating apps. thested this before and after with stadtradel+cyface pro. looks good!