### PR TITLE
Task/mov 530 reenable used apis for sr and document usages

### DIFF
--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -60,7 +60,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.2.4
+ * @version 5.2.5
  * @since 2.0.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -398,7 +398,7 @@ public class DataCapturingServiceTest {
         // Now let's make sure all measurements started and stopped as expected
         TestUtils.lockAndWait(2, TimeUnit.SECONDS, lock, condition);
 
-        List<Measurement> measurements = oocut.getCachedMeasurements();
+        List<Measurement> measurements = oocut.loadMeasurements();
         assertThat(measurements.size(), is(equalTo(3)));
 
         final long measurementId1 = startUpFinishedHandler1.receivedMeasurementIdentifier;
@@ -662,13 +662,13 @@ public class DataCapturingServiceTest {
             NoSuchMeasurementException, CursorIsNullException {
 
         final long measurementIdentifier = startAndCheckThatLaunched();
-        final List<Measurement> measurements = oocut.getCachedMeasurements();
+        final List<Measurement> measurements = oocut.loadMeasurements();
         assertThat(measurements.size(), is(equalTo(1)));
 
         pauseAndCheckThatStopped(measurementIdentifier);
 
         resumeAndCheckThatLaunched(measurementIdentifier);
-        final List<Measurement> newMeasurements = oocut.getCachedMeasurements();
+        final List<Measurement> newMeasurements = oocut.loadMeasurements();
         assertThat(measurements.size() == newMeasurements.size(), is(equalTo(true)));
 
         stopAndCheckThatStopped(measurementIdentifier);
@@ -698,7 +698,7 @@ public class DataCapturingServiceTest {
         final long measurementIdentifier = startAndCheckThatLaunched();
 
         // Check sensor data
-        final List<Measurement> measurements = oocut.getCachedMeasurements();
+        final List<Measurement> measurements = oocut.loadMeasurements();
         assertThat(measurements.size() > 0, is(equalTo(true)));
         TestUtils.lockAndWait(3, TimeUnit.SECONDS, lock, condition);
         assertThat(testListener.getCapturedData().size() > 0, is(equalTo(true)));
@@ -710,10 +710,9 @@ public class DataCapturingServiceTest {
      * Tests whether reconnect throws no exception when called without a running background service and leaves the
      * DataCapturingService in the correct state (<code>isDataCapturingServiceRunning</code> is <code>false</code>.
      *
-     * @throws DataCapturingException Fails the test if anything goes wrong.
      */
     @Test
-    public void testReconnectOnNonRunningServer() throws DataCapturingException {
+    public void testReconnectOnNonRunningServer() {
         oocut.reconnect();
         assertThat(oocut.getIsRunning(), is(equalTo(false)));
     }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingListener.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingListener.java
@@ -16,6 +16,7 @@ import de.cyface.persistence.model.Vehicle;
  * @version 1.3.2
  * @since 1.0.0
  */
+// Needs to be public as this interface is implemented by sdk implementing apps (SR)
 public interface DataCapturingListener {
     /**
      * Called everytime the capturing service received a location Fix and thus is able to track its position.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingListener.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingListener.java
@@ -13,7 +13,7 @@ import de.cyface.persistence.model.Vehicle;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.3.2
+ * @version 1.3.3
  * @since 1.0.0
  */
 // Needs to be public as this interface is implemented by sdk implementing apps (SR)

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -51,6 +51,7 @@ import android.os.Messenger;
 import android.os.RemoteException;
 import android.preference.PreferenceManager;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -581,7 +582,8 @@ public abstract class DataCapturingService {
      *
      * @throws IllegalStateException If communication with background service is not successful.
      */
-    @SuppressWarnings("WeakerAccess") // TODO: not used by RS. Do we use it in our app?
+    @SuppressWarnings("WeakerAccess") // TODO: not used by RS. But should be used by all apps to rebind the app after it
+                                      // has been shut down. -> add example to Readme
     public void reconnect() {
 
         final Lock lock = new ReentrantLock();

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -51,7 +51,6 @@ import android.os.Messenger;
 import android.os.RemoteException;
 import android.preference.PreferenceManager;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -97,11 +96,11 @@ import de.cyface.utils.Validate;
  * @since 1.0.0
  */
 public abstract class DataCapturingService {
+
     /**
      * {@code true} if data capturing is running; {@code false} otherwise.
      */
     private boolean isRunning;
-
     /**
      * A flag indicating whether the background service is currently stopped or in the process of stopping. This flag is
      * used to prevent multiple lifecycle methods from interrupting a stop process or being called, while no service is
@@ -247,6 +246,7 @@ public abstract class DataCapturingService {
      *             register a {@link UIListener} to ask the user for this permission and prevent the
      *             <code>Exception</code>. If the <code>Exception</code> was thrown the service does not start.
      */
+    // This life-cycle method is called by sdk implementing apps (e.g. SR)
     public void start(final @NonNull DataCapturingListener listener, final @NonNull Vehicle vehicle,
             final @NonNull StartUpFinishedHandler finishedHandler)
             throws DataCapturingException, MissingPermissionException, CursorIsNullException {
@@ -299,7 +299,7 @@ public abstract class DataCapturingService {
      *             prior to stopping.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API
+    @SuppressWarnings("WeakerAccess") // This life-cycle method is called by sdk implementing apps (e.g. SR)
     public void stop(final @NonNull ShutDownFinishedHandler finishedHandler)
             throws NoSuchMeasurementException, CursorIsNullException {
         Log.d(TAG, "Stopping asynchronously!");
@@ -354,7 +354,7 @@ public abstract class DataCapturingService {
      *             {@link #start(DataCapturingListener, Vehicle, StartUpFinishedHandler)} prior to pausing.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API
+    @SuppressWarnings("WeakerAccess") // This life-cycle method is called by sdk implementing apps (e.g. SR)
     public void pause(final @NonNull ShutDownFinishedHandler finishedHandler)
             throws DataCapturingException, NoSuchMeasurementException, CursorIsNullException {
         Log.d(TAG, "Pausing asynchronously.");
@@ -366,7 +366,6 @@ public abstract class DataCapturingService {
         Log.v(TAG, "Locking in asynchronous pause.");
         try {
             setIsStoppingOrHasStopped(true);
-            final Measurement currentMeasurement = capturingBehaviour.loadCurrentlyCapturedMeasurement();
 
             if (!stopService(finishedHandler)) {
                 throw new DataCapturingException("No active service found to be paused.");
@@ -411,7 +410,7 @@ public abstract class DataCapturingService {
      *             {@link #start(DataCapturingListener, Vehicle, StartUpFinishedHandler)} prior to pausing.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API
+    @SuppressWarnings("WeakerAccess") // This life-cycle method is called by sdk implementing apps (e.g. SR)
     public void resume(final @NonNull StartUpFinishedHandler finishedHandler) throws DataCapturingException,
             MissingPermissionException, NoSuchMeasurementException, CursorIsNullException {
         Log.d(TAG, "Resuming asynchronously.");
@@ -454,16 +453,15 @@ public abstract class DataCapturingService {
     }
 
     /**
-     * Returns all {@link Measurement}s currently on this device. This includes currently running ones
-     * ({@link MeasurementStatus#OPEN}, {@link MeasurementStatus#PAUSED}, {@link MeasurementStatus#FINISHED} and
-     * {@link MeasurementStatus#SYNCED} measurements.
+     * Returns all {@link Measurement}s currently on this device, no matter the current {@link MeasurementStatus}.
      *
      * @return A list containing all {@code Measurement}s currently stored on this device by this application. An empty
      *         list if there are no such measurements, but never <code>null</code>.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // because we need to support this API - TODO: really?
-    public @NonNull List<Measurement> getCachedMeasurements() throws CursorIsNullException {
+    @SuppressWarnings({"unused"}) // Used by cyface flavour tests
+    @NonNull
+    List<Measurement> loadMeasurements() throws CursorIsNullException {
         return persistenceLayer.loadMeasurements();
     }
 
@@ -475,7 +473,7 @@ public abstract class DataCapturingService {
      *         such measurements, but never <code>null</code>.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("unused") // TODO because?
+    @SuppressWarnings("unused") // Because sdk implementing apps (SR) use this api to load the finished measurements
     public @NonNull List<Measurement> loadMeasurements(@NonNull final MeasurementStatus status)
             throws CursorIsNullException {
         return persistenceLayer.loadMeasurements(status);
@@ -485,7 +483,7 @@ public abstract class DataCapturingService {
      * @return The identifier used to qualify {@link Measurement}s from this capturing service with the server receiving
      *         the {@code Measurement}s. This needs to be world wide unique.
      */
-    @SuppressWarnings("unused") // because implementing apps (SR) uses this to access the device id
+    @SuppressWarnings({"unused", "WeakerAccess"}) // sdk implementing apps (SR) uses this to access the device id
     public @NonNull String getDeviceIdentifier() {
         return deviceIdentifier;
     }
@@ -494,20 +492,20 @@ public abstract class DataCapturingService {
      * @param measurementIdentifier The identifier of the measurement to load.
      * @return The measurement corresponding to the provided <code>measurementIdentifier</code> or <code>null</code> if
      *         no such measurement exists.
-     * @throws DataCapturingException If accessing the data storage fails.
-     *             /
-     *             public Measurement loadMeasurement(final long measurementIdentifier) throws DataCapturingException {
-     *             return persistenceLayer.loadMeasurement(measurementIdentifier);
-     *             } TODO: required?
+     * @throws CursorIsNullException when the {@link ContentProvider} is inaccessible
      */
+    @SuppressWarnings("unused") // Because sdk implementing apps (SR) use this to load single measurements
+    public Measurement loadMeasurement(final long measurementIdentifier) throws CursorIsNullException {
+        return persistenceLayer.loadMeasurement(measurementIdentifier);
+    }
 
     /**
-     * Forces the service to synchronize all Measurements now if a connection is available. If this is not called the
-     * service might wait for an opportune moment to start synchronization.
+     * Forces the service to synchronize all {@link Measurement}s now if a connection is available. If this is not
+     * called the service might wait for an opportune moment to start synchronization.
      *
      * @throws SynchronisationException If synchronisation account information is invalid or not available.
      */
-    @SuppressWarnings({"WeakerAccess", "unused"}) // because we need to support this API - TODO: really?
+    @SuppressWarnings({"WeakerAccess", "unused"}) // TODO: not used by SR. Is this required by our app?
     public void forceMeasurementSynchronisation(final @NonNull String username) throws SynchronisationException {
         Account account = getWiFiSurveyor().getOrCreateAccount(username);
         getWiFiSurveyor().scheduleSyncNow(account);
@@ -522,7 +520,7 @@ public abstract class DataCapturingService {
      *
      *         TODO provide a custom list implementation that loads only small portions into memory.
      */
-    @SuppressWarnings("unused") // Because we need to support this interface for the Movebis project
+    @SuppressWarnings("unused") // Because sdk implementing apps (RS) use this api to display the tracks
     public List<GeoLocation> loadTrack(final @NonNull Measurement measurement) throws NoSuchMeasurementException {
         return persistenceLayer.loadTrack(measurement);
     }
@@ -535,19 +533,15 @@ public abstract class DataCapturingService {
      * @throws NoSuchMeasurementException If the provided measurement was <code>null</code> due to some unknown reasons.
      *             This is an API violation. You are not supposed to provide <code>null</code> measurements to this
      *             method.
-     *             /
-     *             public void deleteMeasurement(final @NonNull Measurement measurement) throws
-     *             NoSuchMeasurementException {
-     *             persistenceLayer.delete(measurement);
-     *             }
-     *
-     *             TODO [MOV-487]: do we still need to offer this interface or can we delete the method?
      */
+    @SuppressWarnings("unused") // Because sdk implementing apps (SR) use this to delete measurements
+    public void deleteMeasurement(final @NonNull Measurement measurement) throws NoSuchMeasurementException {
+        persistenceLayer.delete(measurement);
+    }
 
     /**
      * This method checks for whether the service is currently running or not. Since this requires an asynchronous inter
-     * process communication, it should be
-     * considered a long running operation.
+     * process communication, it should be considered a long running operation.
      *
      * @param timeout The timeout of how long to wait for the service to answer before deciding it is not running. After
      *            this timeout has passed the <code>IsRunningCallback#timedOut()</code> method is called. Since the
@@ -557,23 +551,23 @@ public abstract class DataCapturingService {
      * @param unit The unit of time specified by timeout.
      * @param callback Called as soon as the current state of the service has become clear.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API
+    @SuppressWarnings("WeakerAccess") // Sdk implementing apps (SR) use this method to check for capturing after resume
     public void isRunning(final long timeout, final TimeUnit unit, final @NonNull IsRunningCallback callback) {
-        Log.d(TAG, "Checking isRunning?");
+        Log.v(TAG, "Checking isRunning?");
         final PongReceiver pongReceiver = new PongReceiver(getContext(), deviceIdentifier);
         pongReceiver.checkIsRunningAsync(timeout, unit, callback);
     }
 
     /**
-     * Disconnects your app from the <code>DataCapturingService</code>. Data capturing will continue in the background
+     * Disconnects your app from the {@link DataCapturingService}. Data capturing will continue in the background
      * but you will not receive any updates about this. This frees some resources used for communication and cleanly
-     * shuts down the connection. You should call this method in your <code>Activity</code> lifecycle
-     * <code>onStop</code>. You may call <code>reconnect</code> if you would like to receive updates again, like in your
-     * <code>Activity</code> lifecycle <code>onRestart</code> method.
+     * shuts down the connection. You should call this method in your {@link android.app.Activity} lifecycle
+     * {@code Activity#onStop()}. You may call {@link #reconnect()} if you would like to receive updates again, as in
+     * {@code Activity#onRestart()}.
      *
      * @throws DataCapturingException If service was not connected.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // because we need to support this API - TODO really?
+    @SuppressWarnings({"unused", "WeakerAccess"}) // TODO: not used by RS. Do we use it in our app?
     public void disconnect() throws DataCapturingException {
         unbind();
     }
@@ -587,8 +581,8 @@ public abstract class DataCapturingService {
      *
      * @throws IllegalStateException If communication with background service is not successful.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API - TODO really?
-    public void reconnect() throws DataCapturingException {
+    @SuppressWarnings("WeakerAccess") // TODO: not used by RS. Do we use it in our app?
+    public void reconnect() {
 
         final Lock lock = new ReentrantLock();
         final Condition condition = lock.newCondition();
@@ -605,7 +599,7 @@ public abstract class DataCapturingService {
             }
         };
 
-        // TODO: Maybe move the timeout time to a parameter.
+        // TODO: Maybe move the timeout time to a parameter. [already fixed in open PR]
         isRunning(500L, TimeUnit.MILLISECONDS, reconnectCallback); // throws IllegalStateException
 
         // Wait for isRunning to return.
@@ -625,8 +619,7 @@ public abstract class DataCapturingService {
     /**
      * @param uiListener A listener for events which the UI might be interested in.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API - TODO really?
-    public void setUiListener(final @NonNull UIListener uiListener) {
+    void setUiListener(final @NonNull UIListener uiListener) {
         this.uiListener = uiListener;
     }
 
@@ -634,7 +627,7 @@ public abstract class DataCapturingService {
      * @return A listener for events which the UI might be interested in. This might be <code>null</code> if there has
      *         been no previous call to {@link #setUiListener(UIListener)}.
      */
-    @SuppressWarnings("unused") // because we need to support this API - TODO: really?
+    @SuppressWarnings("unused") // Used by MovebisDataCapturingService
     UIListener getUiListener() {
         return uiListener;
     }
@@ -753,8 +746,8 @@ public abstract class DataCapturingService {
      * @param context Current <code>Activity</code> context.
      * @return Either <code>true</code> if permission was or has been granted; <code>false</code> otherwise.
      */
-    // BooleanMethodIsAlwaysInverted - because it's better readable this way
-    // WeakerAccess - //TODO because ?
+    // BooleanMethodIsAlwaysInverted: Better readable this way
+    // WeakerAccess: Used by MovebisDataCapturingService
     @SuppressWarnings({"BooleanMethodIsAlwaysInverted", "WeakerAccess"})
     boolean checkFineLocationAccess(final @NonNull Context context) {
         boolean permissionAlreadyGranted = ActivityCompat.checkSelfPermission(context,
@@ -861,8 +854,8 @@ public abstract class DataCapturingService {
     /**
      * @return {@code true} if data capturing is running; {@code false} otherwise.
      */
-    @SuppressWarnings("WeakerAccess") // because we need to support this API - TODO: really?
-    public boolean getIsRunning() {
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // Used by a test in the cyface flavour
+    boolean getIsRunning() {
         Log.d(TAG, "Getting isRunning with value " + isRunning);
         return isRunning;
     }
@@ -892,7 +885,7 @@ public abstract class DataCapturingService {
      *
      * @param listener A listener that is notified of important events during synchronization.
      */
-    @SuppressWarnings("unused") // because we need to support this API - TODO: really?
+    @SuppressWarnings("unused") // TODO not used by SR. Does our app use this?
     public void addConnectionStatusListener(final @NonNull ConnectionStatusListener listener) {
         this.connectionStatusReceiver.addListener(listener);
     }
@@ -903,7 +896,7 @@ public abstract class DataCapturingService {
      *
      * @param listener A listener that is notified of important events during synchronization.
      */
-    @SuppressWarnings("unused") // because we need to support this API - TODO: really?
+    @SuppressWarnings("unused") // TODO not used by SR. Does our app use this?
     public void removeConnectionStatusListener(final @NonNull ConnectionStatusListener listener) {
         this.connectionStatusReceiver.removeListener(listener);
     }
@@ -911,8 +904,8 @@ public abstract class DataCapturingService {
     /**
      * Unregisters the {@link ConnectionStatusReceiver} when no more needed.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // because we need to support this API - TODO: really?
-    public void shutdownConnectionStatusReceiver() {
+    @SuppressWarnings({"unused"}) // TODO: Used by CyfaceDataCapturingService but is the caller used?
+    void shutdownConnectionStatusReceiver() {
         this.connectionStatusReceiver.shutdown(getContext());
     }
 
@@ -1100,7 +1093,7 @@ public abstract class DataCapturingService {
          *
          * @param listener A listener that is notified of important events during data capturing.
          */
-        @SuppressWarnings("unused") // because we need to support this API - TODO: really?
+        @SuppressWarnings("unused") // TODO why is this method not used anywhere?
         void removeListener(final @NonNull DataCapturingListener listener) {
             this.listener.remove(listener);
         }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -482,10 +482,10 @@ public abstract class DataCapturingService {
     }
 
     /**
-     * @return The identifier used to qualify measurements from this capturing service with the server receiving the
-     *         measurements. This needs to be world wide unique.
+     * @return The identifier used to qualify {@link Measurement}s from this capturing service with the server receiving
+     *         the {@code Measurement}s. This needs to be world wide unique.
      */
-    @SuppressWarnings("unused") // because we need to support this API - TODO: really?
+    @SuppressWarnings("unused") // because implementing apps (SR) uses this to access the device id
     public @NonNull String getDeviceIdentifier() {
         return deviceIdentifier;
     }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -92,7 +92,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 9.3.3
+ * @version 10.0.0
  * @since 1.0.0
  */
 public abstract class DataCapturingService {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/ui/UIListener.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/ui/UIListener.java
@@ -9,7 +9,7 @@ import de.cyface.datacapturing.DataCapturingService;
  * user interface relevant events.
  *
  * @author Klemens Muthmann
- * @version 1.0.1
+ * @version 1.0.2
  * @since 2.0.0
  */
 // Needs to be public as this interface is implemented by sdk implementing apps (SR)

--- a/datacapturing/src/main/java/de/cyface/datacapturing/ui/UIListener.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/ui/UIListener.java
@@ -12,6 +12,7 @@ import de.cyface.datacapturing.DataCapturingService;
  * @version 1.0.1
  * @since 2.0.0
  */
+// Needs to be public as this interface is implemented by sdk implementing apps (SR)
 public interface UIListener {
     /**
      * Handler for location changes occurring even while no tracking is active.

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -38,7 +38,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.1
+ * @version 5.0.0
  * @since 2.0.0
  */
 @SuppressWarnings({"unused", "WeakerAccess"}) // Sdk implementing apps (SR) use to create a DataCapturingService

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -38,9 +38,10 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.0
+ * @version 4.0.1
  * @since 2.0.0
  */
+@SuppressWarnings({"unused", "WeakerAccess"}) // Sdk implementing apps (SR) use to create a DataCapturingService
 public class MovebisDataCapturingService extends DataCapturingService {
 
     /**
@@ -101,7 +102,7 @@ public class MovebisDataCapturingService extends DataCapturingService {
      *             fails.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("WeakerAccess") // TODO - because?
+    @SuppressWarnings("WeakerAccess") // Sdk implementing apps (SR) use this to create the DataCapturingService
     public MovebisDataCapturingService(final @NonNull Context context, final @NonNull String dataUploadServerAddress,
             final @NonNull UIListener uiListener, final long locationUpdateRate,
             @NonNull final EventHandlingStrategy eventHandlingStrategy) throws SetupException, CursorIsNullException {
@@ -113,7 +114,7 @@ public class MovebisDataCapturingService extends DataCapturingService {
      * Creates a new completely initialized {@link MovebisDataCapturingService}.
      * This variant is required to test the ContentProvider.
      *
-     * (!) ATTENTION: This constructor is only for testing to be able to inject authority and account type. Use
+     * ATTENTION: This constructor is only for testing to be able to inject authority and account type. Use
      * {@link MovebisDataCapturingService#MovebisDataCapturingService(Context, String, UIListener, long, EventHandlingStrategy)}
      * instead.
      *
@@ -149,34 +150,12 @@ public class MovebisDataCapturingService extends DataCapturingService {
     }
 
     /**
-     * Creates a new completely initialized {@link MovebisDataCapturingService}.
-     *
-     * @param context The context (i.e. <code>Activity</code>) handling this service.
-     * @param dataUploadServerAddress The server address running an API that is capable of receiving data captured by
-     *            this service.
-     * @param uiListener A listener for events which the UI might be interested in.
-     * @param locationUpdateRate The maximum rate of location updates to receive in seconds. Set this to <code>0L</code>
-     *            if you would like to be notified as often as possible.
-     * @throws SetupException If initialization of this service facade fails or writing the components preferences
-     *             fails.
-     * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
-     *
-     *             FIXME: can we remove one of these constructors?
-     */
-    @SuppressWarnings("unused") // Because?
-    public MovebisDataCapturingService(final @NonNull Context context, final @NonNull String dataUploadServerAddress,
-            final @NonNull UIListener uiListener, final long locationUpdateRate)
-            throws SetupException, CursorIsNullException {
-        this(context, dataUploadServerAddress, uiListener, locationUpdateRate, new IgnoreEventsStrategy());
-    }
-
-    /**
      * Starts the reception of location updates for the user interface. No tracking is started with this method. This is
      * purely intended for display purposes. The received locations are forwarded to the {@link UIListener} provided to
      * the constructor.
      */
-    @SuppressWarnings("WeakerAccess") // TODO Because ?
-    @SuppressLint("MissingPermission") // This is ok. We are checking the permission, but lint is too dump to notice.
+    @SuppressWarnings("WeakerAccess") // Because sdk implementing apps (SR) use this method to receive location updates
+    @SuppressLint("MissingPermission") // Because we are checking the permission, but lint does not notice this.
     public void startUILocationUpdates() {
         if (uiUpdatesActive) {
             return;
@@ -194,7 +173,6 @@ public class MovebisDataCapturingService extends DataCapturingService {
                     0L, locationListener);
             uiUpdatesActive = true;
         }
-
     }
 
     /**
@@ -202,7 +180,7 @@ public class MovebisDataCapturingService extends DataCapturingService {
      *
      * @see #startUILocationUpdates()
      */
-    @SuppressWarnings("WeakerAccess") // TODO: Because?
+    @SuppressWarnings("WeakerAccess") // Because sdk implementing apps (SR) use this method to receive location updates
     public void stopUILocationUpdates() {
         if (!uiUpdatesActive) {
             return;
@@ -219,7 +197,7 @@ public class MovebisDataCapturingService extends DataCapturingService {
      * @param token The auth token to add.
      * @throws SynchronisationException If unable to create an appropriate account with the Android account system.
      */
-    @SuppressWarnings({"WeakerAccess", "unused"}) // Because this is required by the STADTRADELN app
+    @SuppressWarnings({"WeakerAccess", "unused"}) // Because sdk implementing apps (SR) use this to inject a token
     public void registerJWTAuthToken(final @NonNull String username, final @NonNull String token)
             throws SynchronisationException {
         AccountManager accountManager = AccountManager.get(getContext());
@@ -232,28 +210,27 @@ public class MovebisDataCapturingService extends DataCapturingService {
 
     /**
      * Removes the <a href="https://jwt.io/">JWT</a> auth token for a specific username from the system. If that
-     * username was not registered with
-     * {@link #registerJWTAuthToken(String, String)} this method simply does nothing.
+     * username was not registered with {@link #registerJWTAuthToken(String, String)} this method simply does nothing.
      *
      * @param username The username of the user to remove the auth token for.
      */
-    @SuppressWarnings({"WeakerAccess", "unused"}) // Because this is required by the STADTRADELN app
+    @SuppressWarnings({"WeakerAccess", "unused"}) // Because sdk implementing apps (SR) use this to inject a token
     public void deregisterJWTAuthToken(final @NonNull String username) {
         getWiFiSurveyor().deleteAccount(username);
     }
 
-    /**
+    /*
+     * Uncommented as this seems not to be used by SR.
      * Sets whether this <code>MovebisDataCapturingService</code> should synchronize data only on WiFi or on all data
      * connections.
-     * 
      * @param state If <code>true</code> the <code>MovebisDataCapturingService</code> synchronizes data only if
-     *            connected to a WiFi network; if <code>false</code> it synchronizes as soon as a data connection is
-     *            available. The second option might use up the users data plan rapidly so use it sparingly.
+     * connected to a WiFi network; if <code>false</code> it synchronizes as soon as a data connection is
+     * available. The second option might use up the users data plan rapidly so use it sparingly.
+     * /
+     * public void syncOnWiFiOnly(final boolean state) {
+     * getWiFiSurveyor().syncOnWiFiOnly(state);
+     * }
      */
-    @SuppressWarnings("unused") // TODO: Because?
-    public void syncOnWiFiOnly(final boolean state) {
-        getWiFiSurveyor().syncOnWiFiOnly(state);
-    }
 
     /**
      * Checks whether the user has granted the <code>ACCESS_COARSE_LOCATION</code> permission and notifies the UI to ask


### PR DESCRIPTION
This is a stacked PR (ontop of the other) because:
* this task is urgent (red)
* I branched from the open PR branch and did not want to cherry-pick if I don't have to

I.e. after reviewing the other PR you can review the changes here so I can merge this back a bit quicker.

The changes here are mostly documentation of API methods and enabling of uncommented api methods used in the SR code.