### PR TITLE
Task/mov 535 sync without wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ public class MainFragment extends Fragment implements ConnectionStatusListener {
                         // As the login was successful we now register the account correctly:
                         final AccountManager accountManager = AccountManager.get(context);
                         final Account account = accountManager.getAccountsByType(ACCOUNT_TYPE)[0];
-                        dataCapturingService.makeAccountSyncable(account, syncEnabledPreference);
+                        dataCapturingService.getWifiSurveyor().makeAccountSyncable(account, syncEnabledPreference);
 
                         dataCapturingService.startWifiSurveyor();
                     } catch (OperationCanceledException e) {

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ make sure to call `persistenceLayer.loadCurrentlyCapturedMeasurement()` *on each
 update* to always have the most recent information. For this you need to implement the `DataCapturingListener`
 interface to be notified on `onNewGeoLocationAcquired(GeoLocation)` events.
 
+**Load Track**
+
+To display the track of a finished measurement use `persistenceLayer.loadTrack(measurementId)`
+which returns a list of lists containing `GeoLocations`. Currently there is always just one
+sub list which contains the full track. We'll change this soon so that tracks are sliced into sub tracks
+when pause/resume was used which is the reason behind the return type. 
+
 #### Delete measurements
 
 The following code snippet shows how to manage stored measurements:

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ public class MainFragment extends Fragment implements ConnectionStatusListener {
         
         // Login and create account 
         // a) Static token variant:
-        dataCapturingService.createAccount(username, token);
-        dataCapturingService.startWifiSurveyor();
+        dataCapturingService.registerJWTAuthToken(username, token);
         // or b) Login via LoginActivity and using dynamic tokens
         // The LoginActivity is called by Android which handles the account creation
         accountManager.addAccount(ACCOUNT_TYPE, AUTH_TOKEN_TYPE, null, null,

--- a/README.md
+++ b/README.md
@@ -236,22 +236,27 @@ You must not use the same notification identifier for any other notification dis
 
 
 ### Access Measurements via PersistenceLayer
-You can manage measurements via the `PersistenceLayer<DefaultPersistenceBehaviour>` as demonstrated in the sample code below (see *Delete measurements*).
+Use the `PersistenceLayer<DefaultPersistenceBehaviour>` to manage and load measurements as demonstrated in the sample code below.
 
-* When you only have the id of a measurement and need the `Measurement` object please use `persistenceLayer.loadMeasurement(mid)`
-to load the measurement with its metadata from the database.
-
-* To access all measurements, including `MeasurementStatus#FINISHED` and `MeasurementStatus#SYNCED` measurements use `loadMeasurement(mid)` or `loadMeasurements()` or `loadMeasurements(MeasurementStatus)`.
+* Use `persistenceLayer.loadMeasurement(mid)` to load a specific measurement 
+* Use `loadMeasurements()` or `loadMeasurements(MeasurementStatus)` to load multiple measurements (of a specific state)
                                                               
-**ATTENTION** The attributes (such as the distance) of `MeasurementStatus#OPEN` and `MeasurementStatus#PAUSED`
-measurements are only valid in the moment it's loaded from the database. Changes
+#### Load measurements                                                              
+                                                              
+**ATTENTION:** The attributes of `MeasurementStatus#OPEN` and `MeasurementStatus#PAUSED`
+measurements are only valid in the moment they are loaded from the database. Changes
 after this call are not pushed into the `Measurement` object returned by this call.
-In order to display the distance for an ongoing measurement (which changes about each second)
-make sure to call `persistenceLayer.loadCurrentlyCapturedMeasurement()` on each location
-update to always have the most recent information. Implement the `DataCapturingListener`
+
+**Measurement distance**
+
+To display the distance for an ongoing measurement (which is updated about once per second)
+make sure to call `persistenceLayer.loadCurrentlyCapturedMeasurement()` *on each location
+update* to always have the most recent information. For this you need to implement the `DataCapturingListener`
 interface to be notified on `onNewGeoLocationAcquired(GeoLocation)` events.
 
 #### Delete measurements
+
+The following code snippet shows how to manage stored measurements:
 
 ```java
 public class MeasurementOverviewFragment extends Fragment {

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -66,7 +66,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.3.5
+ * @version 5.3.6
  * @since 1.0.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -460,7 +460,7 @@ public class CapturedDataWriterTest {
         List<Measurement> measurements = oocut.loadMeasurements();
         assertThat(measurements.size(), is(equalTo(1)));
         for (Measurement loadedMeasurement : measurements) {
-            assertThat(oocut.loadTrack(loadedMeasurement.getIdentifier()).size(), is(equalTo(1)));
+            assertThat(oocut.loadTrack(loadedMeasurement.getIdentifier()).get(0).size(), is(equalTo(1)));
         }
     }
 

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -6,6 +6,7 @@ import static de.cyface.synchronization.CyfaceAuthenticator.LOGIN_ACTIVITY;
 import java.util.List;
 
 import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.content.ContentProvider;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -189,5 +190,15 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
                 throw new IllegalStateException(e1);
             }
         }
+    }
+
+    // FIXME: cleaner?
+    // to reuse the addPeriodicSync from WifiSurveyor
+    // Periodic sync is always enabled as we disable synchronization via setIsSyncable and the
+    // auto-synchronization is disabled via setSyncAutomatically which fixed MOV-535.
+    // In MovebisDataCapturingService this is called when the JWT token is registered
+    // FIXME: also update tests and docu same was as we change the code
+    public void addPeriodicSync(@NonNull final String username) throws SynchronisationException {
+        getWiFiSurveyor().getOrCreateAccount(username);
     }
 }

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -208,8 +208,25 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
      * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
      *
      * @param account The {@code Account} to be used for synchronization
+     * @param enabled True if sync should be enabled
      */
-    public void makeAccountSyncable(@NonNull final Account account) {
-        getWiFiSurveyor().makeAccountSyncable(account);
+    public void makeAccountSyncable(@NonNull final Account account, boolean enabled) {
+        getWiFiSurveyor().makeAccountSyncable(account, enabled);
+    }
+
+    /**
+     * @return True if synchronization is enabled
+     */
+    public boolean isSyncEnabled() {
+        return getWiFiSurveyor().isSyncEnabled();
+    }
+
+    /**
+     * Allows to enable or disable synchronization completely.
+     *
+     * @param enabled True if synchronization should be enabled
+     */
+    public void setSyncEnabled(final boolean enabled) {
+        getWiFiSurveyor().setSyncEnabled(enabled);
     }
 }

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -25,7 +25,9 @@ import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.Vehicle;
+import de.cyface.synchronization.NetworkCallback;
 import de.cyface.synchronization.SynchronisationException;
+import de.cyface.synchronization.WiFiSurveyor;
 import de.cyface.utils.CursorIsNullException;
 
 /**
@@ -197,6 +199,23 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
     // auto-synchronization is disabled via setSyncAutomatically which fixed MOV-535.
     // In MovebisDataCapturingService this is called when the JWT token is registered
     // FIXME: also update tests and docu same was as we change the code
+
+    /**
+     * Sets up an already existing {@code Account} to work with the {@link WiFiSurveyor}.
+     * <p>
+     * <b>ATTENTION:</b> SDK implementing apps need to use this method if they cannot use
+     * {@link WiFiSurveyor#createAccount(String, String)}.
+     * <p>
+     * This has the following reasons:
+     * - {@code ContentResolver#addPeriodicSync()} is always registered until {@link WiFiSurveyor#deleteAccount(String)}
+     * is called
+     * - {@code ContentResolver#setSyncAutomatically()} is automatically updated via {@link NetworkCallback}s and
+     * defines if a connection is available which can be used for synchronization (dependent on
+     * {@link WiFiSurveyor#syncOnWiFiOnly(boolean)}). Using this instead of the periodicSync flag fixed MOV-535.
+     * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
+     *
+     * @param account The {@code Account} to be used for synchronization
+     */
     public void makeAccountSyncable(@NonNull final Account account) {
         getWiFiSurveyor().makeAccountSyncable(account);
     }

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -35,7 +35,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 8.0.0
+ * @version 8.1.0
  * @since 2.0.0
  */
 public final class CyfaceDataCapturingService extends DataCapturingService {
@@ -192,13 +192,6 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
             }
         }
     }
-
-    // FIXME: cleaner?
-    // to reuse the makeAccountSyncable from WifiSurveyor
-    // Periodic sync is always enabled as we disable synchronization via setIsSyncable and the
-    // auto-synchronization is disabled via setSyncAutomatically which fixed MOV-535.
-    // In MovebisDataCapturingService this is called when the JWT token is registered
-    // FIXME: also update tests and docu same was as we change the code
 
     /**
      * Sets up an already existing {@code Account} to work with the {@link WiFiSurveyor}.

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -6,7 +6,6 @@ import static de.cyface.synchronization.CyfaceAuthenticator.LOGIN_ACTIVITY;
 import java.util.List;
 
 import android.accounts.Account;
-import android.accounts.AccountManager;
 import android.content.ContentProvider;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -193,12 +192,12 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
     }
 
     // FIXME: cleaner?
-    // to reuse the addPeriodicSync from WifiSurveyor
+    // to reuse the makeAccountSyncable from WifiSurveyor
     // Periodic sync is always enabled as we disable synchronization via setIsSyncable and the
     // auto-synchronization is disabled via setSyncAutomatically which fixed MOV-535.
     // In MovebisDataCapturingService this is called when the JWT token is registered
     // FIXME: also update tests and docu same was as we change the code
-    public void addPeriodicSync(@NonNull final String username) throws SynchronisationException {
-        getWiFiSurveyor().getOrCreateAccount(username);
+    public void makeAccountSyncable(@NonNull final Account account) {
+        getWiFiSurveyor().makeAccountSyncable(account);
     }
 }

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -204,7 +204,8 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
      * is called
      * - {@code ContentResolver#setSyncAutomatically()} is automatically updated via {@link NetworkCallback}s and
      * defines if a connection is available which can be used for synchronization (dependent on
-     * {@link WiFiSurveyor#syncOnWiFiOnly(boolean)}). Using this instead of the periodicSync flag fixed MOV-535.
+     * {@link WiFiSurveyor#setSyncOnUnMeteredNetworkOnly(boolean)}). Using this instead of the periodicSync flag fixed
+     * MOV-535.
      * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
      *
      * @param account The {@code Account} to be used for synchronization

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -25,9 +25,7 @@ import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.Vehicle;
-import de.cyface.synchronization.NetworkCallback;
 import de.cyface.synchronization.SynchronisationException;
-import de.cyface.synchronization.WiFiSurveyor;
 import de.cyface.utils.CursorIsNullException;
 
 /**
@@ -35,7 +33,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 8.1.0
+ * @version 9.0.0
  * @since 2.0.0
  */
 public final class CyfaceDataCapturingService extends DataCapturingService {
@@ -191,43 +189,5 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
                 throw new IllegalStateException(e1);
             }
         }
-    }
-
-    /**
-     * Sets up an already existing {@code Account} to work with the {@link WiFiSurveyor}.
-     * <p>
-     * <b>ATTENTION:</b> SDK implementing apps need to use this method if they cannot use
-     * {@link WiFiSurveyor#createAccount(String, String)}.
-     * <p>
-     * This has the following reasons:
-     * - {@code ContentResolver#addPeriodicSync()} is always registered until {@link WiFiSurveyor#deleteAccount(String)}
-     * is called
-     * - {@code ContentResolver#setSyncAutomatically()} is automatically updated via {@link NetworkCallback}s and
-     * defines if a connection is available which can be used for synchronization (dependent on
-     * {@link WiFiSurveyor#setSyncOnUnMeteredNetworkOnly(boolean)}). Using this instead of the periodicSync flag fixed
-     * MOV-535.
-     * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
-     *
-     * @param account The {@code Account} to be used for synchronization
-     * @param enabled True if sync should be enabled
-     */
-    public void makeAccountSyncable(@NonNull final Account account, boolean enabled) {
-        getWiFiSurveyor().makeAccountSyncable(account, enabled);
-    }
-
-    /**
-     * @return True if synchronization is enabled
-     */
-    public boolean isSyncEnabled() {
-        return getWiFiSurveyor().isSyncEnabled();
-    }
-
-    /**
-     * Allows to enable or disable synchronization completely.
-     *
-     * @param enabled True if synchronization should be enabled
-     */
-    public void setSyncEnabled(final boolean enabled) {
-        getWiFiSurveyor().setSyncEnabled(enabled);
     }
 }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -80,7 +80,7 @@ import de.cyface.utils.Validate;
  * An object of this class handles the lifecycle of starting and stopping data capturing as well as transmitting results
  * to an appropriate server. To avoid using the users traffic or incurring costs, the service waits for Wifi access
  * before transmitting any data. You may however force synchronization if required, using
- * {@link #forceMeasurementSynchronisation()}.
+ * {@link #scheduleSyncNow()} ()}.
  * <p>
  * An object of this class is not thread safe and should only be used once per application. You may start and stop the
  * service as often as you like and reuse the object.
@@ -91,7 +91,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 13.0.0
+ * @version 14.0.0
  * @since 1.0.0
  */
 public abstract class DataCapturingService {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -91,7 +91,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 14.0.0
+ * @version 14.0.1
  * @since 1.0.0
  */
 public abstract class DataCapturingService {
@@ -685,7 +685,8 @@ public abstract class DataCapturingService {
      *
      * @return The currently active <code>WiFiSurveyor</code>.
      */
-    WiFiSurveyor getWiFiSurveyor() {
+    @SuppressWarnings("WeakerAccess") // SDK implementing apps (CY) use this to access control the surveyor
+    public WiFiSurveyor getWiFiSurveyor() {
         return surveyor;
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -32,7 +32,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import android.Manifest;
-import android.accounts.Account;
 import android.content.ComponentName;
 import android.content.ContentProvider;
 import android.content.Context;
@@ -73,7 +72,6 @@ import de.cyface.synchronization.BundlesExtrasCodes;
 import de.cyface.synchronization.ConnectionStatusListener;
 import de.cyface.synchronization.ConnectionStatusReceiver;
 import de.cyface.synchronization.SyncService;
-import de.cyface.synchronization.SynchronisationException;
 import de.cyface.synchronization.WiFiSurveyor;
 import de.cyface.utils.CursorIsNullException;
 import de.cyface.utils.Validate;
@@ -82,7 +80,7 @@ import de.cyface.utils.Validate;
  * An object of this class handles the lifecycle of starting and stopping data capturing as well as transmitting results
  * to an appropriate server. To avoid using the users traffic or incurring costs, the service waits for Wifi access
  * before transmitting any data. You may however force synchronization if required, using
- * {@link #forceMeasurementSynchronisation(String)}.
+ * {@link #forceMeasurementSynchronisation()}.
  * <p>
  * An object of this class is not thread safe and should only be used once per application. You may start and stop the
  * service as often as you like and reuse the object.
@@ -475,15 +473,12 @@ public abstract class DataCapturingService {
     }
 
     /**
-     * Forces the service to synchronize all {@link Measurement}s now if a connection is available. If this is not
-     * called the service might wait for an opportune moment to start synchronization.
-     *
-     * @throws SynchronisationException If synchronisation account information is invalid or not available.
+     * Schedules data synchronization for right now. This does not mean synchronization is going to start immediately.
+     * The Android system still decides when it is convenient.
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // Used by implementing app (CY)
-    public void forceMeasurementSynchronisation(final @NonNull String username) throws SynchronisationException {
-        Account account = getWiFiSurveyor().getOrCreateAccount(username);
-        getWiFiSurveyor().scheduleSyncNow(account);
+    public void scheduleSyncNow() {
+        getWiFiSurveyor().scheduleSyncNow();
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -246,7 +246,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
     }
 
     /**
-     * We don't use {@link #startService(Intent)} to pause of stop the service because we prefer to use a lock and
+     * We don't use {@link #startService(Intent)} to pause or stop the service because we prefer to use a lock and
      * finally in the {@link DataCapturingService}'s life-cycle methods instead. This also avoids headaches with
      * replacing the return statement from {@link #stopService(Intent)} by the return by {@code #startService()}.
      *

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -14,13 +14,13 @@
  */
 package de.cyface.datacapturing.backend;
 
+import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
+import static de.cyface.datacapturing.DiskConsumption.spaceAvailable;
 import static de.cyface.synchronization.BundlesExtrasCodes.AUTHORITY_ID;
 import static de.cyface.synchronization.BundlesExtrasCodes.DISTANCE_CALCULATION_STRATEGY_ID;
 import static de.cyface.synchronization.BundlesExtrasCodes.EVENT_HANDLING_STRATEGY_ID;
 import static de.cyface.synchronization.BundlesExtrasCodes.MEASUREMENT_ID;
 import static de.cyface.synchronization.BundlesExtrasCodes.STOPPED_SUCCESSFULLY;
-import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
-import static de.cyface.datacapturing.DiskConsumption.spaceAvailable;
 
 import java.lang.ref.WeakReference;
 import java.util.Collections;
@@ -50,7 +50,6 @@ import android.os.RemoteException;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import de.cyface.synchronization.BundlesExtrasCodes;
 import de.cyface.datacapturing.DataCapturingService;
 import de.cyface.datacapturing.DistanceCalculationStrategy;
 import de.cyface.datacapturing.EventHandlingStrategy;
@@ -68,6 +67,7 @@ import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.PointMetaData;
 import de.cyface.persistence.serialization.MeasurementSerializer;
 import de.cyface.persistence.serialization.Point3dFile;
+import de.cyface.synchronization.BundlesExtrasCodes;
 import de.cyface.utils.CursorIsNullException;
 import de.cyface.utils.Validate;
 
@@ -80,7 +80,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.0.2
+ * @version 5.0.3
  * @since 2.0.0
  */
 public class DataCapturingBackgroundService extends Service implements CapturingProcessListener {

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -53,7 +53,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.0.0
+ * @version 7.0.1
  * @since 2.0.0
  */
 @SuppressWarnings({"unused", "WeakerAccess"}) // Sdk implementing apps (SR) use to create a DataCapturingService

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -35,7 +35,6 @@ import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.synchronization.SynchronisationException;
-import de.cyface.synchronization.WiFiSurveyor;
 import de.cyface.utils.CursorIsNullException;
 
 /**
@@ -54,7 +53,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.0.1
+ * @version 8.0.0
  * @since 2.0.0
  */
 @SuppressWarnings({"unused", "WeakerAccess"}) // Sdk implementing apps (SR) use to create a DataCapturingService
@@ -242,25 +241,6 @@ public class MovebisDataCapturingService extends DataCapturingService {
     @SuppressWarnings({"WeakerAccess", "unused"}) // Because sdk implementing apps (SR) use this to inject a token
     public void deregisterJWTAuthToken(final @NonNull String username) {
         getWiFiSurveyor().deleteAccount(username);
-    }
-
-    /**
-     * Sets whether synchronization should happen only on
-     * {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED}
-     * networks or on all networks.
-     * <p>
-     * For Android devices lower than {@code android.os.Build.VERSION_CODES.LOLLIPOP}
-     * {@code ConnectivityManager.TYPE_WIFI}
-     * is used as a synonym for the more general "not metered" capability.
-     *
-     * @param state If {@code true} the {@link WiFiSurveyor} synchronizes data only if connected to a
-     *            {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED} network; if
-     *            {@code false} it synchronizes as soon as a data connection is available. The second option might use
-     *            up the users data plan rapidly so use it sparingly. The default value is {@code true}.
-     * @throws SynchronisationException If no current Android <code>Context</code> is available.
-     */
-    public void setSyncOnUnMeteredNetworkOnly(final boolean state) throws SynchronisationException {
-        getWiFiSurveyor().setSyncOnUnMeteredNetworkOnly(state);
     }
 
     /**

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -223,9 +223,10 @@ public class MovebisDataCapturingService extends DataCapturingService {
     @SuppressWarnings({"WeakerAccess", "unused"}) // Because sdk implementing apps (SR) use this to inject a token
     public void registerJWTAuthToken(final @NonNull String username, final @NonNull String token)
             throws SynchronisationException {
-        AccountManager accountManager = AccountManager.get(getContext());
+        final AccountManager accountManager = AccountManager.get(getContext());
 
-        Account synchronizationAccount = getWiFiSurveyor().getOrCreateAccount(username);
+        // FIXME: is the account actually created by the SDK or by STAD?
+        final Account synchronizationAccount = getWiFiSurveyor().getOrCreateAccount(username);
 
         accountManager.setAuthToken(synchronizationAccount, AUTH_TOKEN_TYPE, token);
         getWiFiSurveyor().startSurveillance(synchronizationAccount);

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -225,8 +225,8 @@ public class MovebisDataCapturingService extends DataCapturingService {
             throws SynchronisationException {
         final AccountManager accountManager = AccountManager.get(getContext());
 
-        // FIXME: is the account actually created by the SDK or by STAD?
-        final Account synchronizationAccount = getWiFiSurveyor().getOrCreateAccount(username);
+        // Create a "dummy" account used for auto synchronization. Null password as the token is static
+        final Account synchronizationAccount = getWiFiSurveyor().createAccount(username, null);
 
         accountManager.setAuthToken(synchronizationAccount, AUTH_TOKEN_TYPE, token);
         getWiFiSurveyor().startSurveillance(synchronizationAccount);

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -257,8 +257,9 @@ public class MovebisDataCapturingService extends DataCapturingService {
      *            {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED} network; if
      *            {@code false} it synchronizes as soon as a data connection is available. The second option might use
      *            up the users data plan rapidly so use it sparingly. The default value is {@code true}.
+     * @throws SynchronisationException If no current Android <code>Context</code> is available.
      */
-    public void setSyncOnUnMeteredNetworkOnly(final boolean state) {
+    public void setSyncOnUnMeteredNetworkOnly(final boolean state) throws SynchronisationException {
         getWiFiSurveyor().setSyncOnUnMeteredNetworkOnly(state);
     }
 

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -35,6 +35,7 @@ import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.synchronization.SynchronisationException;
+import de.cyface.synchronization.WiFiSurveyor;
 import de.cyface.utils.CursorIsNullException;
 
 /**
@@ -243,18 +244,23 @@ public class MovebisDataCapturingService extends DataCapturingService {
         getWiFiSurveyor().deleteAccount(username);
     }
 
-    /*
-     * Uncommented as this seems not to be used by SR.
-     * Sets whether this <code>MovebisDataCapturingService</code> should synchronize data only on WiFi or on all data
-     * connections.
-     * @param state If <code>true</code> the <code>MovebisDataCapturingService</code> synchronizes data only if
-     * connected to a WiFi network; if <code>false</code> it synchronizes as soon as a data connection is
-     * available. The second option might use up the users data plan rapidly so use it sparingly.
-     * /
-     * public void syncOnWiFiOnly(final boolean state) {
-     * getWiFiSurveyor().syncOnWiFiOnly(state);
-     * }
+    /**
+     * Sets whether synchronization should happen only on
+     * {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED}
+     * networks or on all networks.
+     * <p>
+     * For Android devices lower than {@code android.os.Build.VERSION_CODES.LOLLIPOP}
+     * {@code ConnectivityManager.TYPE_WIFI}
+     * is used as a synonym for the more general "not metered" capability.
+     *
+     * @param state If {@code true} the {@link WiFiSurveyor} synchronizes data only if connected to a
+     *            {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED} network; if
+     *            {@code false} it synchronizes as soon as a data connection is available. The second option might use
+     *            up the users data plan rapidly so use it sparingly. The default value is {@code true}.
      */
+    public void setSyncOnUnMeteredNetworkOnly(final boolean state) {
+        getWiFiSurveyor().setSyncOnUnMeteredNetworkOnly(state);
+    }
 
     /**
      * Checks whether the user has granted the <code>ACCESS_COARSE_LOCATION</code> permission and notifies the UI to ask

--- a/persistence/src/main/java/de/cyface/persistence/DefaultFileAccess.java
+++ b/persistence/src/main/java/de/cyface/persistence/DefaultFileAccess.java
@@ -21,7 +21,7 @@ import de.cyface.utils.Validate;
  * Implementation of the {@link FileAccessLayer} which accesses the real file system.
  *
  * @author Armin Schnabel
- * @version 3.1.2
+ * @version 3.1.3
  * @since 3.0.0
  */
 public final class DefaultFileAccess implements FileAccessLayer {

--- a/persistence/src/main/java/de/cyface/persistence/DefaultFileAccess.java
+++ b/persistence/src/main/java/de/cyface/persistence/DefaultFileAccess.java
@@ -115,10 +115,9 @@ public final class DefaultFileAccess implements FileAccessLayer {
     public File createFile(@NonNull Context context, long measurementId, String folderName, String fileExtension) {
         final File file = getFilePath(context, measurementId, folderName, fileExtension);
         if (file.exists()) {
-            // Before we threw an Exception which we saw in PlayStore. The cause was probably due to a race condition
-            // when the second onDataCaptured call comes in while the first didn't finish creating the file in time.
-            // Now: soft-catch. If the following warning never occurs we might not need to create files differently.
-            Log.w(TAG, "CreateFile ignored as it already exists: " + file.getPath());
+            // Before we threw an Exception which we saw in PlayStore. This happens because we call this method
+            // also when we resume a measurement in which case the files usually already exist.
+            Log.d(TAG, "CreateFile ignored as it already exists (probably resuming): " + file.getPath());
             return file;
         }
 

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -45,7 +45,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 10.1.0
+ * @version 11.0.0
  * @since 2.0.0
  */
 public class PersistenceLayer<B extends PersistenceBehaviour> {
@@ -490,9 +490,12 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
     }
 
     /**
-     * Loads the track of {@link GeoLocation} objects for the provided {@link Measurement}. This method loads the
-     * complete track into memory. For large tracks this could slow down the device or even reach the applications
-     * memory limit.
+     * Loads the track of {@link GeoLocation} objects for the provided {@link Measurement}.
+     * TODO [STAD-6]: Slice the tracks into sub tracks when the measurement was paused and resumed.
+     * Right now the full unsliced track is always the only sub track that is returned.
+     * <p>
+     * This method loads the complete track into memory. For large tracks this could slow down the device or even reach
+     * the applications memory limit.
      *
      * TODO [CY-4438]: From the current implementations (MeasurementContentProviderClient loader and resolver.query) is
      * the loader the faster solution. However, we should upgrade the database access as Android changed it's API.
@@ -504,8 +507,9 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      *         {@code GeoLocation}s.
      */
     @SuppressWarnings("unused") // Sdk implementing apps (RS) use this api to display the tracks
-    public List<GeoLocation> loadTrack(final long measurementIdentifier) {
+    public List<List<GeoLocation>> loadTrack(final long measurementIdentifier) {
 
+        final List<List<GeoLocation>> subTracks = new ArrayList<>();
         Cursor cursor = null;
         try {
             cursor = resolver.query(getGeoLocationsUri(), null, GeoLocationsTable.COLUMN_MEASUREMENT_FK + "=?",
@@ -515,17 +519,18 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
                 return Collections.emptyList();
             }
 
-            final List<GeoLocation> geoLocations = new ArrayList<>(cursor.getCount());
+            final List<GeoLocation> fullTrack = new ArrayList<>(cursor.getCount());
             while (cursor.moveToNext()) {
                 final double lat = cursor.getDouble(cursor.getColumnIndex(GeoLocationsTable.COLUMN_LAT));
                 final double lon = cursor.getDouble(cursor.getColumnIndex(GeoLocationsTable.COLUMN_LON));
                 final long timestamp = cursor.getLong(cursor.getColumnIndex(GeoLocationsTable.COLUMN_GEOLOCATION_TIME));
                 final double speed = cursor.getDouble(cursor.getColumnIndex(GeoLocationsTable.COLUMN_SPEED));
                 final float accuracy = cursor.getFloat(cursor.getColumnIndex(GeoLocationsTable.COLUMN_ACCURACY));
-                geoLocations.add(new GeoLocation(lat, lon, timestamp, speed, accuracy));
+                fullTrack.add(new GeoLocation(lat, lon, timestamp, speed, accuracy));
             }
 
-            return geoLocations;
+            subTracks.add(fullTrack);
+            return subTracks;
         } finally {
             if (cursor != null) {
                 cursor.close();

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -49,7 +49,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.2.2
+ * @version 2.2.3
  * @since 2.4.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -120,8 +120,8 @@ public final class SyncAdapterTest {
         // GeoLocation
         final Measurement loadedMeasurement = persistence.loadMeasurement(measurementIdentifier);
         assertThat(loadedMeasurement, notNullValue());
-        List<GeoLocation> geoLocations = persistence.loadTrack(loadedMeasurement.getIdentifier());
-        assertThat(geoLocations.size(), is(1));
+        final List<List<GeoLocation>> subTracks = persistence.loadTrack(loadedMeasurement.getIdentifier());
+        assertThat(subTracks.get(0).size(), is(1));
     }
 
     /**
@@ -178,8 +178,8 @@ public final class SyncAdapterTest {
         // GeoLocation
         final Measurement loadedMeasurement = persistence.loadMeasurement(measurementIdentifier);
         assertThat(loadedMeasurement, notNullValue());
-        List<GeoLocation> geoLocations = persistence.loadTrack(loadedMeasurement.getIdentifier());
-        assertThat(geoLocations.size(), is(locationCount));
+        final List<List<GeoLocation>> subTracks = persistence.loadTrack(loadedMeasurement.getIdentifier());
+        assertThat(subTracks.get(0).size(), is(locationCount));
     }
 
     /**

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -16,9 +16,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Categories;
 import org.junit.runner.RunWith;
 
 import android.accounts.Account;
@@ -51,7 +49,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.2.1
+ * @version 2.2.2
  * @since 2.4.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -71,7 +71,10 @@ public final class SyncAdapterTest {
 
             Object statusChangeListenerHandle = ContentResolver.addStatusChangeListener(
                     ContentResolver.SYNC_OBSERVER_TYPE_ACTIVE | ContentResolver.SYNC_OBSERVER_TYPE_PENDING, observer);
-            ContentResolver.requestSync(account, AUTHORITY, Bundle.EMPTY);
+            final Bundle params = new Bundle();
+            params.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
+            params.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
+            ContentResolver.requestSync(account, AUTHORITY, params);
 
             lock.lock();
             try {

--- a/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
@@ -1,7 +1,6 @@
 package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.TAG;
-import static de.cyface.synchronization.WiFiSurveyor.SYNC_INTERVAL;
 
 import android.accounts.Account;
 import android.annotation.TargetApi;
@@ -10,8 +9,8 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
-import android.os.Bundle;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 
 /**
@@ -56,21 +55,24 @@ public class NetworkCallback extends ConnectivityManager.NetworkCallback {
             return;
         }
 
-        if (!surveyor.synchronizationIsActive() && surveyor.isConnected()) {
-            // Try synchronization periodically
-            boolean cyfaceAccountSyncIsEnabled = ContentResolver.getSyncAutomatically(currentSynchronizationAccount,
-                    authority);
-            boolean masterAccountSyncIsEnabled = ContentResolver.getMasterSyncAutomatically();
+        final boolean connectionLost = surveyor.synchronizationIsActive() && !surveyor.isConnected();
+        final boolean connectionEstablished = !surveyor.synchronizationIsActive() && surveyor.isConnected();
 
-            if (cyfaceAccountSyncIsEnabled && masterAccountSyncIsEnabled) {
-                Log.d(TAG, "Enabling periodic sync.");
-                ContentResolver.addPeriodicSync(currentSynchronizationAccount, authority, Bundle.EMPTY, SYNC_INTERVAL);
+        if (connectionEstablished) {
+            if (!ContentResolver.getMasterSyncAutomatically()) {
+                Log.d(TAG, "onCapabilitiesChanged: master sync is disabled. Aborting.");
+                return;
             }
+
+            // Enable auto-synchronization - periodic flag is always pre set for all account by us
+            Log.v(TAG, "onCapabilitiesChanged: setSyncAutomatically.");
+            ContentResolver.setSyncAutomatically(currentSynchronizationAccount, authority, true);
             surveyor.setSynchronizationIsActive(true);
-        } else if (surveyor.synchronizationIsActive() && !surveyor.isConnected()) {
-            // wifi connection was lost
-            Log.d(TAG, "Disabling periodic sync.");
-            ContentResolver.removePeriodicSync(currentSynchronizationAccount, authority, Bundle.EMPTY);
+
+        } else if (connectionLost) {
+
+            Log.v(TAG, "onCapabilitiesChanged: setSyncAutomatically to false.");
+            ContentResolver.setSyncAutomatically(currentSynchronizationAccount, authority, false);
             surveyor.setSynchronizationIsActive(false);
         }
     }

--- a/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
  * newly connected network.
  *
  * @author Armin Schnabel
- * @version 1.1.2
+ * @version 1.1.3
  * @since 3.0.0
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -18,6 +18,7 @@ import android.accounts.AuthenticatorException;
 import android.accounts.NetworkErrorException;
 import android.content.AbstractThreadedSyncAdapter;
 import android.content.ContentProviderClient;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SyncResult;
@@ -85,7 +86,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
     public void onPerformSync(final @NonNull Account account, final @NonNull Bundle extras,
             final @NonNull String authority, final @NonNull ContentProviderClient provider,
             final @NonNull SyncResult syncResult) {
-        Log.d(TAG, "Sync started.");
+        Log.d(TAG, "Sync started");
 
         final Context context = getContext();
         final MeasurementSerializer serializer = new MeasurementSerializer(new DefaultFileAccess());

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -18,7 +18,6 @@ import android.accounts.AuthenticatorException;
 import android.accounts.NetworkErrorException;
 import android.content.AbstractThreadedSyncAdapter;
 import android.content.ContentProviderClient;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SyncResult;
@@ -43,7 +42,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.4.1
+ * @version 2.4.2
  * @since 2.0.0
  */
 public final class SyncAdapter extends AbstractThreadedSyncAdapter {

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -31,7 +31,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.0
+ * @version 4.0.1
  * @since 2.0.0
  */
 public class WiFiSurveyor extends BroadcastReceiver {
@@ -339,7 +339,8 @@ public class WiFiSurveyor extends BroadcastReceiver {
      */
     public boolean isConnected() {
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        // Using "metered" code from 8.0+ as Wifi Networks are seen as metered in 6.0.1 MOV-568
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Validate.notNull(connectivityManager);
             final Network activeNetwork = connectivityManager.getActiveNetwork();
             final NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -31,7 +31,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.1
+ * @version 5.0.0
  * @since 2.0.0
  */
 public class WiFiSurveyor extends BroadcastReceiver {
@@ -113,17 +113,22 @@ public class WiFiSurveyor extends BroadcastReceiver {
     }
 
     /**
-     * Starts the WiFi* connection status surveillance. If a WiFi connection is active data synchronization is started.
-     * If the WiFi goes back down synchronization is deactivated.
+     * Starts the connection status surveillance. If a syncable connection is active data synchronization is started.
+     * If the connection goes back down synchronization is deactivated.
      * <p>
-     * The method also schedules an immediate synchronization run after the WiFi has been connected.
+     * You can allow metered connections as syncable by setting {@link #setSyncOnUnMeteredNetworkOnly(boolean)} to
+     * false.
+     * The default value is true.
      * <p>
-     * ATTENTION: If you use this method do not forget to call {@link #stopSurveillance()}, at some time in the future
+     * The method also schedules an immediate synchronization run after the syncable connection has been connected.
+     * <p>
+     * <b>ATTENTION:</b> If you use this method do not forget to call {@link #stopSurveillance()}, at some time in the
+     * future
      * or you will waste system resources.
      * <p>
-     * ATTENTION: Starting at version {@link Build.VERSION_CODES#LOLLIPOP} and higher instead of expecting only "WiFi"
-     * connections as "not metered" we use the {@link NetworkCapabilities#NET_CAPABILITY_NOT_METERED} as synonym as
-     * suggested by Android.
+     * <b>ATTENTION:</b> Starting at version {@code Build.VERSION_CODES.O} and higher instead of
+     * treating only "WiFi" connections as "not metered" we use the
+     * {@code NetworkCapabilities#NET_CAPABILITY_NOT_METERED} as synonym as suggested by Android.
      *
      * @param account Starts surveillance of the WiFi connection status for this account.
      * @throws SynchronisationException If no current Android <code>Context</code> is available.
@@ -296,7 +301,7 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * is called
      * - {@code ContentResolver#setSyncAutomatically()} is automatically updated via {@link NetworkCallback}s and
      * defines if a connection is available which can be used for synchronization (dependent on
-     * {@link WiFiSurveyor#setSyncOnUnMeteredNetworkOnly(boolean)}). Using this instead of the periodicSync flag fixed
+     * {@link #setSyncOnUnMeteredNetworkOnly(boolean)}). Using this instead of the periodicSync flag fixed
      * MOV-535.
      * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
      *
@@ -333,13 +338,14 @@ public class WiFiSurveyor extends BroadcastReceiver {
     }
 
     /**
-     * Checks whether the device is connected with a syncable network (WiFi if {@link #syncOnUnMeteredNetworkOnly}).
+     * Checks whether the device is connected with a syncable network (see
+     * {@link #setSyncOnUnMeteredNetworkOnly(boolean)}).
      *
      * @return <code>true</code> if a syncable connection is available; <code>false</code> otherwise.
      */
     public boolean isConnected() {
 
-        // Using "metered" code from 8.0+ as Wifi Networks are seen as metered in 6.0.1 MOV-568
+        // Using the newer code from 8.0+ as Wifi networks are seen as metered in 6.0.1 (MOV-568)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Validate.notNull(connectivityManager);
             final Network activeNetwork = connectivityManager.getActiveNetwork();
@@ -384,9 +390,9 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED}
      * networks or on all networks.
      * <p>
-     * For Android devices lower than {@code android.os.Build.VERSION_CODES.LOLLIPOP}
-     * {@code ConnectivityManager.TYPE_WIFI}
-     * is used as a synonym for the more general "not metered" capability.
+     * <b>ATTENTION:</b> Starting at version {@code Build.VERSION_CODES.O} and higher instead of
+     * treating only "WiFi" connections as "not metered" we use the
+     * {@code NetworkCapabilities#NET_CAPABILITY_NOT_METERED} as synonym as suggested by Android.
      *
      * @param state If {@code true} the {@link WiFiSurveyor} synchronizes data only if connected to a
      *            {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED} network; if

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -292,25 +292,28 @@ public class WiFiSurveyor extends BroadcastReceiver {
     }
 
     /**
-     * Sets up a already existing {@code Account} to work with the {@link WiFiSurveyor}.
+     * Sets up an already existing {@code Account} to work with the {@link WiFiSurveyor}.
      * <p>
-     * <b>ATTENTION:</b> SDK implementing apps need to use this method if they have to create the account by themselves.
-     * This is required because the {@code WifiSurveyor} uses the following account flags:
-     * - {@code ContentResolver#addPeriodicSync()} is always registered until {@link #deleteAccount(String)} is called
+     * <b>ATTENTION:</b> SDK implementing apps need to use this method if they cannot use
+     * {@link WiFiSurveyor#createAccount(String, String)}.
+     * <p>
+     * This has the following reasons:
+     * - {@code ContentResolver#addPeriodicSync()} is always registered until {@link WiFiSurveyor#deleteAccount(String)}
+     * is called
      * - {@code ContentResolver#setSyncAutomatically()} is automatically updated via {@link NetworkCallback}s and
      * defines if a connection is available which can be used for synchronization (dependent on
-     * {@link #syncOnWiFiOnly(boolean)}). Using this instead of the periodicSync flag fixed MOV-535.
+     * {@link WiFiSurveyor#syncOnWiFiOnly(boolean)}). Using this instead of the periodicSync flag fixed MOV-535.
      * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
      *
-     * @param newAccount The {@code Account} to be used for synchronization
+     * @param account The {@code Account} to be used for synchronization
      */
-    public void makeAccountSyncable(@NonNull final Account newAccount) {
+    public void makeAccountSyncable(@NonNull final Account account) {
         // FIXME: Make app use a dcs.setIsSyncable() API and ensure it's called onCreateView for a stored pref
         // Synchronization can be disabled via *FIXME*
-        ContentResolver.setIsSyncable(newAccount, authority, 1);
+        ContentResolver.setIsSyncable(account, authority, 1);
 
         // PeriodicSync must always be on and is removed in {@code #removeAccount()}
-        ContentResolver.addPeriodicSync(newAccount, authority, Bundle.EMPTY, SYNC_INTERVAL);
+        ContentResolver.addPeriodicSync(account, authority, Bundle.EMPTY, SYNC_INTERVAL);
     }
 
     /**

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -277,7 +277,7 @@ public class WiFiSurveyor extends BroadcastReceiver {
             Validate.isTrue(accountManager.getAccountsByType(accountType).length == 1);
             Log.v(TAG, "New account added");
 
-            makeAccountSyncable(newAccount);
+            makeAccountSyncable(newAccount, true);
         }
 
         return newAccount;
@@ -298,13 +298,13 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * - {@code ContentResolver#setIsSyncable()} is used to disable synchronization manually and completely
      *
      * @param account The {@code Account} to be used for synchronization
+     * @param enabled True if the synchronization should be enabled
      */
     @SuppressWarnings("unused") // Used by CyfaceDataCapturingService
-    public void makeAccountSyncable(@NonNull final Account account) {
-        // TODO [MOV-580]: Make app use a dcs.setIsSyncable() API and ensure it's called onCreateView for a stored pref
+    public void makeAccountSyncable(@NonNull final Account account, boolean enabled) {
 
-        // Synchronization can be disabled via *** TODO [MOV-580] add newly added API name
-        ContentResolver.setIsSyncable(account, authority, 1);
+        // Synchronization can be disabled via {@link #setSyncEnabled()}
+        ContentResolver.setIsSyncable(account, authority, enabled ? 1 : 0);
 
         // PeriodicSync must always be on and is removed in {@code #removeAccount()}
         ContentResolver.addPeriodicSync(account, authority, Bundle.EMPTY, SYNC_INTERVAL);
@@ -394,5 +394,21 @@ public class WiFiSurveyor extends BroadcastReceiver {
 
     void setSynchronizationIsActive(boolean synchronizationIsActive) {
         this.synchronizationIsActive = synchronizationIsActive;
+    }
+
+    /**
+     * @return True if synchronization is enabled
+     */
+    public boolean isSyncEnabled() {
+        return ContentResolver.getIsSyncable(currentSynchronizationAccount, authority) == 1;
+    }
+
+    /**
+     * Allows to enable or disable synchronization completely.
+     *
+     * @param enabled True if synchronization should be enabled
+     */
+    public void setSyncEnabled(final boolean enabled) {
+        ContentResolver.setIsSyncable(currentSynchronizationAccount, authority, enabled ? 1 : 0);
     }
 }

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -19,6 +19,7 @@ import org.robolectric.shadows.ShadowNetwork;
 import org.robolectric.shadows.ShadowNetworkInfo;
 
 import android.accounts.Account;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
@@ -34,7 +35,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.1.1
+ * @version 1.1.2
  * @since 2.0.0
  */
 @RunWith(RobolectricTestRunner.class)
@@ -46,8 +47,8 @@ public class WiFiSurveyorTest {
      */
     private ShadowConnectivityManager shadowConnectivityManager;
     private ConnectivityManager connectivityManager;
-    private ShadowNetwork shadowOfActiveNetwork;
-    private ShadowNetworkInfo shadowOfActiveNetworkInfo;
+    //private ShadowNetwork shadowOfActiveNetwork;
+    //private ShadowNetworkInfo shadowOfActiveNetworkInfo;
     /**
      * An object of the class under test.
      */
@@ -85,15 +86,18 @@ public class WiFiSurveyorTest {
         assertTrue(activeInfo != null && activeInfo.isConnected());
         Validate.notNull(oocut.connectivityManager);*/
 
-        switchWiFiConnection(false);
-        assertThat(oocut.isConnected(), is(equalTo(false)));
+        //switchWiFiConnection(false);
+        //assertThat(oocut.isConnected(), is(equalTo(false)));
+
+        // Not sure why this is not set by default (in roboelectric test environment)
+        ContentResolver.setMasterSyncAutomatically(true);
 
         Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
 
         switchWiFiConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));
-        assertThat(oocut.synchronizationIsActive(), is(equalTo(true))); // FIXME: this is false
+        assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
     }
 
     /**
@@ -102,6 +106,10 @@ public class WiFiSurveyorTest {
      */
     @Test
     public void testMobileConnectivity() throws SynchronisationException {
+
+        // Not sure why this is not set by default (in roboelectric test environment)
+        ContentResolver.setMasterSyncAutomatically(true);
+
         Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
 
@@ -112,6 +120,7 @@ public class WiFiSurveyorTest {
 
         switchMobileConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));
+        assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
     }
 
     /**

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -99,11 +99,11 @@ public class WiFiSurveyorTest {
      *
      */
     @Test
-    public void testMobileConnectivity() {
+    public void testMobileConnectivity() throws SynchronisationException {
         switchMobileConnection(false);
 
         switchWiFiConnection(false);
-        oocut.syncOnWiFiOnly(false);
+        oocut.setSyncOnUnMeteredNetworkOnly(false);
         assertThat(oocut.isConnected(), is(equalTo(false)));
         switchMobileConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -3,7 +3,6 @@ package de.cyface.synchronization;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static de.cyface.synchronization.TestUtils.ACCOUNT_TYPE;
 import static de.cyface.synchronization.TestUtils.AUTHORITY;
-import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -15,7 +14,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowConnectivityManager;
-import org.robolectric.shadows.ShadowNetwork;
 import org.robolectric.shadows.ShadowNetworkInfo;
 
 import android.accounts.Account;
@@ -27,7 +25,6 @@ import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 
 import androidx.test.core.app.ApplicationProvider;
-import de.cyface.utils.Validate;
 
 /**
  * Tests the correct functionality of the <code>WiFiSurveyor</code> class. This test requires an active WiFi connection
@@ -35,7 +32,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.1.2
+ * @version 1.1.3
  * @since 2.0.0
  */
 @RunWith(RobolectricTestRunner.class)
@@ -46,9 +43,6 @@ public class WiFiSurveyorTest {
      * The Robolectric shadow used for the Android <code>ConnectivityManager</code>.
      */
     private ShadowConnectivityManager shadowConnectivityManager;
-    private ConnectivityManager connectivityManager;
-    //private ShadowNetwork shadowOfActiveNetwork;
-    //private ShadowNetworkInfo shadowOfActiveNetworkInfo;
     /**
      * An object of the class under test.
      */
@@ -64,7 +58,7 @@ public class WiFiSurveyorTest {
     @Before
     public void setUp() {
         context = ApplicationProvider.getApplicationContext();
-        connectivityManager = getConnectivityManager();
+        ConnectivityManager connectivityManager = getConnectivityManager();
         shadowConnectivityManager = Shadows.shadowOf(connectivityManager);
         oocut = new WiFiSurveyor(context, connectivityManager, AUTHORITY, ACCOUNT_TYPE);
     }
@@ -78,22 +72,14 @@ public class WiFiSurveyorTest {
     @Test
     public void testWifiConnectivity() throws SynchronisationException {
 
-        // Added this block while trying to set the connectivityManager to not null -.-
-        /*NetworkInfo networkInfo = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
-                ConnectivityManager.TYPE_WIFI, 0, true, NetworkInfo.State.CONNECTED);
-        shadowConnectivityManager.setActiveNetworkInfo(networkInfo);
-        NetworkInfo activeInfo = connectivityManager.getActiveNetworkInfo();
-        assertTrue(activeInfo != null && activeInfo.isConnected());
-        Validate.notNull(oocut.connectivityManager);*/
-
-        //switchWiFiConnection(false);
-        //assertThat(oocut.isConnected(), is(equalTo(false)));
-
         // Not sure why this is not set by default (in roboelectric test environment)
         ContentResolver.setMasterSyncAutomatically(true);
 
         Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
+
+        switchWiFiConnection(false);
+        assertThat(oocut.isConnected(), is(equalTo(false)));
 
         switchWiFiConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -78,20 +78,22 @@ public class WiFiSurveyorTest {
     public void testWifiConnectivity() throws SynchronisationException {
 
         // Added this block while trying to set the connectivityManager to not null -.-
-        NetworkInfo networkInfo = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
+        /*NetworkInfo networkInfo = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
                 ConnectivityManager.TYPE_WIFI, 0, true, NetworkInfo.State.CONNECTED);
         shadowConnectivityManager.setActiveNetworkInfo(networkInfo);
         NetworkInfo activeInfo = connectivityManager.getActiveNetworkInfo();
         assertTrue(activeInfo != null && activeInfo.isConnected());
-        Validate.notNull(oocut.connectivityManager);
+        Validate.notNull(oocut.connectivityManager);*/
 
         switchWiFiConnection(false);
         assertThat(oocut.isConnected(), is(equalTo(false)));
+
         Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
+
         switchWiFiConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));
-        assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
+        assertThat(oocut.synchronizationIsActive(), is(equalTo(true))); // FIXME: this is false
     }
 
     /**
@@ -100,11 +102,14 @@ public class WiFiSurveyorTest {
      */
     @Test
     public void testMobileConnectivity() throws SynchronisationException {
-        switchMobileConnection(false);
+        Account account = oocut.createAccount("test", null);
+        oocut.startSurveillance(account);
 
+        switchMobileConnection(false);
         switchWiFiConnection(false);
         oocut.setSyncOnUnMeteredNetworkOnly(false);
         assertThat(oocut.isConnected(), is(equalTo(false)));
+
         switchMobileConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));
     }

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -1,7 +1,6 @@
 package de.cyface.synchronization;
 
 import static android.os.Build.VERSION_CODES.KITKAT;
-import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 import static de.cyface.synchronization.TestUtils.ACCOUNT_TYPE;
 import static de.cyface.synchronization.TestUtils.AUTHORITY;
 import static junit.framework.TestCase.assertTrue;
@@ -87,7 +86,7 @@ public class WiFiSurveyorTest {
 
         switchWiFiConnection(false);
         assertThat(oocut.isConnected(), is(equalTo(false)));
-        Account account = oocut.getOrCreateAccount("test");
+        Account account = oocut.createAccount("test");
         oocut.startSurveillance(account);
         switchWiFiConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
+
 import androidx.test.core.app.ApplicationProvider;
 import de.cyface.utils.Validate;
 
@@ -33,11 +34,11 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.1.0
+ * @version 1.1.1
  * @since 2.0.0
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk=KITKAT) // Because the Roboelectric test don't work on newer devices
+@Config(sdk = KITKAT) // Because the Roboelectric test don't work on newer devices
 public class WiFiSurveyorTest {
 
     /**
@@ -86,7 +87,7 @@ public class WiFiSurveyorTest {
 
         switchWiFiConnection(false);
         assertThat(oocut.isConnected(), is(equalTo(false)));
-        Account account = oocut.createAccount("test");
+        Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
         switchWiFiConnection(true);
         assertThat(oocut.isConnected(), is(equalTo(true)));

--- a/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
+++ b/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
@@ -47,7 +47,7 @@ import de.cyface.utils.Validate;
  * It's located in the main folder to be compiled and imported as dependency in the testImplementations.
  *
  * @author Armin Schnabel
- * @version 4.0.1
+ * @version 4.0.2
  * @since 3.0.0
  */
 public class SharedTestUtils {
@@ -282,8 +282,8 @@ public class SharedTestUtils {
         assertThat(persistence.loadMeasurementStatus(measurementIdentifier), is(equalTo(status)));
 
         // Check the GeoLocations
-        List<GeoLocation> loadedGeoLocations = persistence.loadTrack(measurementIdentifier);
-        assertThat(loadedGeoLocations.size(), is(locationCount));
+        final List<List<GeoLocation>> loadedSubTracks = persistence.loadTrack(measurementIdentifier);
+        assertThat(loadedSubTracks.get(0).size(), is(locationCount));
 
         // We can only check the PointMetaData for measurements which are not open anymore (else it's still in cache)
         if (status != OPEN) {


### PR DESCRIPTION
Behebt den Bug "Synchronization obwohl nicht im Wifi".

Wir hatten "PeriodicSync" entfernt wenn jemand nicht mehr im Wifi ist, trotzdem konnte es noch zu automatischer Synchronisation im Mobilfunknetz kommen da syncAutomatically weiterhin aktiv war.

Ich habe das ganze nun so refactored, dass:
- periodicSync wird beim Erstellen der Account hinzugefügt und erst beim Löschen wieder entfernt - das hat nur einen Effekt, wenn syncAutomatically aktiv ist, daher:
- syncAutomatically wird automatisch gesetzt bzw. entzogen wenn entweder kein Wifi mehr da ist oder SyncOnUnmeteredNetworkOnly nicht aktiv ist und eine Mobilfunkverbindung besteht.
- unsere App nutzt eine neue API "setSyncableEnabled" um die Synchronisation komplett zu deaktivieren bzw. wieder zu aktivieren (Dieses Toggle im NavDrawer)

In meinen manuellen Tests hat das nun genau so funktioniert wie erwartet. Bei den robolectric tests musste ich setMasterSyncAutomatically manuell auf true setzen - mir ist unklar wieso das nicht per default gesetzt ist. Die Tests laufen durch.