### PR TITLE
Task/stad 6 event log

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ public class MeasurementOverviewFragment extends Fragment {
 
 Migration from Earlier Versions
 --------------------------------
+ - [Migrate to 4.0.0-alpha2](documentation/migration-guide_4.0.0-alpha2.md)
  - [Migrate to 4.0.0-alpha1](documentation/migration-guide_4.0.0-alpha1.md)
 
 License

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ servers which are certified by one its trusted Certification Authorities.
 
 #### Content Provider Authority
 
-You need to set the same provider when creating a `DataCapturingService` as well as in your `AndroidManifest.xml`.
+You need to set a provider and to make sure you use the same provider everywhere:
 
 * The `AndroidManifest.xml` is required to override the default content provider as
 declared by the persistence project. This needs to be done by each SDK integrating
@@ -92,6 +92,19 @@ application separately.
 public class Constants {
     public final static String AUTHORITY = "your.domain.app.provider"; // replace this
 }
+```
+
+* Create a resource file `src/main/res/xml/sync_adapter.xml` and use the same provider:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<sync-adapter xmlns:android="http://schemas.android.com/apk/res/android"
+    android:contentAuthority="your.domain.app.provider"
+    android:accountType="your.domain.app"
+    android:userVisible="false"
+    android:supportsUploading="true"
+    android:allowParallelSyncs="false"
+    android:isAlwaysSyncable="true" />
 ```
 
 ### Service Initialization

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To do so place a truststore containing your key in:
     synchronization/src/main/res/raw/truststore.jks
 
 If this (by default empty) file is not replaced, the SDK can only communicate with
-servers which are certified by one its trusted Certification Authorities.
+servers which are certified by one of its trusted Certification Authorities.
 
 #### Content Provider Authority
 
@@ -85,7 +85,7 @@ application separately.
 </manifest>
 ```
 
-* Define your authority which you must use as parameter in for `new Cyface/MovebisDataCapturingService()` (see sample below). 
+* Define your authority which you must use as parameter in `new Cyface/MovebisDataCapturingService()` (see sample below). 
   This must be the same as defined in the `AndroidManifest.xml` above.
   
 ```java
@@ -115,9 +115,9 @@ We provide two interfaces for this service: `CyfaceDataCapturingService` and `Mo
 Unless you are part of the *Movebis project* `CyfaceDataCapturingService` is your candidate.
 
 To keep this documentation lightweight, we currently only use `MovebisDataCapturingService` in the samples
-but the interface for `CyfaceDataCapturingService` are mostly the same.
+but the interface for `CyfaceDataCapturingService` is mostly the same.
 
-The following steps are required in communicate with this service.
+The following steps are required to communicate with this service.
 
 #### Implement Data Capturing Listener
 
@@ -209,7 +209,7 @@ The most likely adaptation an application using the Cyface SDK for Android shoul
 
   Even with `vectorDrawables.useSupportLibrary` enabled the vector drawable won't work as a notification icon (`notificationBuilder.setSmallIcon()`)
   on devices with API < 21. We assume that's because of the way we need to inject your custom notification.
-  A simple fix is to have a the xml in `res/drawable-anydpi-v21/icon.xml` and to generate notification icon PNGs under the same resource name in the usual paths (`res/drawable-**dpi/icon.png`). 
+  A simple fix is to have the xml in `res/drawable-anydpi-v21/icon.xml` and to generate notification icon PNGs under the same resource name in the usual paths (`res/drawable-**dpi/icon.png`). 
   
 #### Start Service
 

--- a/README.md
+++ b/README.md
@@ -3,41 +3,260 @@ Cyface Android SDK
 
 This project contains the Cyface Android SDK which is used by Cyface applications to capture data on Android devices.
 
-- [Setup](#setup)
-- [Known Issues](#known-issues)
-- [How to Integrate the SDK](#how-to-integrate-the-sdk)
-	- [Provide a Custom Capturing Notification](#provide-a-custom-capturing-notification)
-	- [Access Measurements via PersistenceLayer](#access-measurements-via-persistenceLayer)
-	    - [Load Measurements](#load-measurements)
-	    - [Delete Measurements](#delete-measurements)
-	- [TODO: add code sample for the usage of:](#todo-add-code-sample-for-the-usage-of)
+- [How to integrate the SDK](#how-to-integrate-the-sdk)
 - [Migration from Earlier Versions](#migration-from-earlier-versions)
 - [License](#license)
 
-Setup
------
 
-Geo location tracks such as those captured by the Cyface Android SDK, should only be transmitted via a secure HTTPS connection.
-If you use a self-signed certificate the SDK requires a truststore containing the key of the server you are transmitting to.
+How to integrate the SDK
+---------------------------
+
+- [Resource Files](#resource-files)
+    - [Truststore](#truststore)
+    - [Content Provider Authority](#content-provider-authority)
+- [Service Initialization](#service-initialization)
+	- [Implement Data Capturing Listener](#implement-data-capturing-listener)
+	- [Implement UI Listener](#implement-ui-listener)
+	- [Implement Event Handling Strategy](#implement-event-handling-strategy)
+	    - [Custom Capturing Notification](#custom-capturing-notification)
+	- [Start Service](#start-service)
+	- [Reconnect to Service](#reconnect-to-service)
+	- [Link your Login Activity](#link-your-login-activity)
+	- [Start WifiSurveyor](#start-wifisurveyor)
+	- [De-/Register JWT Auth Tokens](#de-register-jwt-auth-tokens)
+	- [Start/Stop UI Location Updates](#startstop-ui-location-updates)
+- [Control Capturing](#control-capturing)
+	- [Start/Stop Capturing](#startstop-capturing)
+	- [Pause/Resume Capturing](#pauseresume-capturing)
+- [Access Measurements](#access-measurements)
+	- [Load finished measurements](#load-finished-measurements)
+	- [Load Tracks](#load-tracks)
+	- [Load Measurement Distance (new feature)](#load-measurement-distance)
+	- [Delete Measurements](#delete-measurements)
+- [Documentation Incomplete](#documentation-incomplete)
+
+### Resource Files
+
+The following steps are required before you can start coding.
+
+#### Truststore
+
+Geo location tracks such as those captured by the Cyface Android SDK, should only be transmitted
+via a secure HTTPS connection.
+
+If you use a self-signed certificate the SDK requires a truststore containing the key of the server
+you are transmitting to.
+
 Since we can not know which public key your server uses, this must be provided by you.
-To do so place a truststore containing your key in
+To do so place a truststore containing your key in:
 
     synchronization/src/main/res/raw/truststore.jks
 
-If this (by default empty) file is not replaced, the SDK can only communicate with servers which are certified by one its trusted Certification Authorities.
+If this (by default empty) file is not replaced, the SDK can only communicate with
+servers which are certified by one its trusted Certification Authorities.
 
-Known Issues
-------------
+#### Content Provider Authority
 
-Problem that still exists is that you need to set the same provider when
-creating a DataCapturingService as well as in your manifest. The
-manifest also is required to override the default content provider as
-declared by the persistence project. This needs to be done by each using
+You need to set the same provider when creating a `DataCapturingService` as well as in your `AndroidManifest.xml`.
+
+* The `AndroidManifest.xml` is required to override the default content provider as
+declared by the persistence project. This needs to be done by each SDK integrating
 application separately.
 
-How to Integrate the SDK
---------------------------
-* Define which Activity should be launched to request the user to log in 
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="your.domain.app"> <!-- replace this! -->
+
+    <application>
+        <!-- This overwrites the provider in the SDK. This way the app can
+        be installed next to other SDK using apps.
+        The "authorities" must match the one in your AndroidManifest.xml! -->
+        <provider
+            android:name="de.cyface.persistence.MeasuringPointsContentProvider"
+            android:authorities="your.domain.app.provider"
+            android:exported="false"
+            android:process=":persistence_process"
+            android:syncable="true"
+            tools:replace="android:authorities" />
+    </application>
+
+</manifest>
+```
+
+* Define your authority which you must use as parameter in for `new Cyface/MovebisDataCapturingService()` (see sample below). 
+  This must be the same as defined in the `AndroidManifest.xml` above.
+  
+```java
+public class Constants {
+    public final static String AUTHORITY = "your.domain.app.provider"; // replace this
+}
+```
+
+### Service Initialization
+
+The core of our SDK is the `DataCapturingService` which controls the capturing process.
+
+We provide two interfaces for this service: `CyfaceDataCapturingService` and `MovebisDataCapturingService`.
+Unless you are part of the *Movebis project* `CyfaceDataCapturingService` is your candidate.
+
+To keep this documentation lightweight, we currently only use `MovebisDataCapturingService` in the samples
+but the interface for `CyfaceDataCapturingService` are mostly the same.
+
+The following steps are required in communicate with this service.
+
+#### Implement Data Capturing Listener
+
+This interface informs your app about data capturing events. Implement the interface to update your UI on those events.
+
+Here is a basic example implementation:
+
+```java
+class DataCapturingListenerImpl implements DataCapturingListener {
+
+    PersistenceLayer<DefaultPersistenceBehaviour> persistence =
+        new PersistenceLayer<>(context, contentResolver, AUTHORITY, new DefaultPersistenceBehaviour());
+    
+    @Override
+    public void onNewGeoLocationAcquired(GeoLocation geoLocation) {
+        
+        // E.g.: load current measurement distance
+        final Measurement measurement;
+        try {
+            measurement = persistenceLayer.loadCurrentlyCapturedMeasurement();
+        } catch (final NoSuchMeasurementException | CursorIsNullException e) {
+            throw new IllegalStateException(e);
+        }
+        
+        final double distanceMeter = measurement.getDistance();
+        // Your logic, e.g. update the UI with the current distance
+    }
+    
+    // The other interface methods
+}
+```
+
+#### Implement UI Listener
+
+This is only required for `MovebisDataCapturingService`.
+
+#### Implement Event Handling Strategy
+
+This interface allows us to inject your custom strategies into our SDK.
+
+##### Custom Capturing Notification
+
+To continuously run an Android service, without the system killing said service,
+it needs to show a notification to the user in the Android status bar.
+
+The Cyface data capturing runs as such a service and thus needs to display such a notification.
+Applications using the Cyface SDK may configure style and behaviour of this notification by
+providing an implementation of `de.cyface.datacapturing.EventHandlingStrategy` to the constructor
+of the `de.cyface.datacapturing.DataCapturingService`.
+
+An example implementation is provided by `de.cyface.datacapturing.IgnoreEventsStrategy`.
+The most important step is to implement the method
+`de.cyface.datacapturing.EventHandlingStrategy#buildCapturingNotification(DataCapturingBackgroundService)`. 
+
+This can look like:
+
+```java
+public class EventHandlingStrategyImpl implements EventHandlingStrategy {
+    
+    @Override
+    public @NonNull Notification buildCapturingNotification(final @NonNull DataCapturingBackgroundService context) {
+      final String channelId = "channel";
+      NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O && notificationManager.getNotificationChannel(channelId)==null) {
+        final NotificationChannel channel = new NotificationChannel(channelId, "Cyface Data Capturing", NotificationManager.IMPORTANCE_DEFAULT);
+        notificationManager.createNotificationChannel(channel);
+      }
+    
+      return new NotificationCompat.Builder(context, channelId)
+        .setContentTitle("Cyface")
+        .setSmallIcon(R.drawable.your_icon) // see "attention" notes below
+        .setContentText("Running Data Capturing")
+        .setOngoing(true)
+        .setAutoCancel(false)
+        .build();
+    }
+}
+```
+
+Further details about how to create a proper notification are available via the [Google developer documentation](https://developer.android.com/guide/topics/ui/notifiers/notifications).
+The most likely adaptation an application using the Cyface SDK for Android should do, is use the `android.app.Notification.Builder.setContentIntent(PendingIntent)` to call the applications main activity if the user presses the notification.
+
+**ATTENTION:**
+* Service notifications require an application wide unique identifier.
+  This identifier is 74.656.
+  Due to limitations in the Android framework, this is not configurable.
+  You must not use the same notification identifier for any other notification displayed by your app!
+* If you want to use a **vector xml drawable as Notification icon** make sure to do the following:
+
+  Even with `vectorDrawables.useSupportLibrary` enabled the vector drawable won't work as a notification icon (`notificationBuilder.setSmallIcon()`)
+  on devices with API < 21. We assume that's because of the way we need to inject your custom notification.
+  A simple fix is to have a the xml in `res/drawable-anydpi-v21/icon.xml` and to generate notification icon PNGs under the same resource name in the usual paths (`res/drawable-**dpi/icon.png`). 
+  
+#### Start Service
+
+To save resources your should create your service when the view is created
+and reuse this instance when you need to communicate with it.
+
+```java
+class MainFragment extends Fragment {
+    
+    private MovebisDataCapturingService dataCapturingService;
+    
+    @Override
+    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
+            final Bundle savedInstanceState) {
+        
+        dataCapturingService = new MovebisDataCapturingService(context, dataUploadServerAddress,
+            uiListener, locationUpdateRate, eventHandlingStrategy, capturingListener);
+        
+        // dataCapturingButton is our sample DataCapturingListenerImpl
+        // Depending on your implementation you need to register the DataCapturingService:
+        this.dataCapturingButton.setDataCapturingService(dataCapturingService);
+    }
+}
+```
+
+#### Reconnect to Service
+
+When your UI resumes you need to reconnect to your service:
+
+The `reconnect()` method returns true when there was a capturing running during reconnect.
+This way we can use the `isRunning()` result from within `reconnect()` and avoid duplicate
+`isRunning()` calls which saves time. 
+
+```java
+public class DataCapturingButton implements DataCapturingListener {
+    
+    PersistenceLayer<DefaultPersistenceBehaviour> persistence =
+        new PersistenceLayer<>(context, contentResolver, AUTHORITY, new DefaultPersistenceBehaviour());
+    
+    public void onResume(@NonNull final CyfaceDataCapturingService dataCapturingService) {
+        
+        if (dataCapturingService.reconnect(IS_RUNNING_CALLBACK_TIMEOUT)) {
+            // Your logic, e.g.:
+            setButtonStatus(button, true);
+        } else {
+            // Attention: reconnect() only returns true if there is an OPEN measurement
+            // To check for PAUSED measurements use the persistence layer.
+            persistence.loadMeasurements(MeasurementStatus.PAUSED);
+            // Your logic, e.g.:
+            setButtonStatus(button, false);
+        }
+    }
+}
+```
+
+#### Link your Login Activity
+
+This is only required for `CyfaceDataCapturingService`. 
+
+Define which Activity should be launched to request the user to log in: 
 
 ```java
 public class CustomApplication extends Application {
@@ -50,54 +269,22 @@ public class CustomApplication extends Application {
 }
 ```
 
-* Start the DataCapturingService to communicate with the SDK
+#### Start WifiSurveyor
 
-```java
-public class MainFragment extends Fragment {
-    
-    private CyfaceDataCapturingService dataCapturingService;
-    
-    @Nullable
-    @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-        final Bundle savedInstanceState) {
-        dataCapturingService = new CyfaceDataCapturingService(/*...,*/
-        customEventHandlingStrategy, capturingListener);
-    }
-}
-```
+This is only required for `CyfaceDataCapturingService`.
 
-or
-
-```java
-
-public class MainFragment extends Fragment {
-    
-    private MovebisDataCapturingService dataCapturingService;
-    
-    @Nullable
-    @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-        final Bundle savedInstanceState) {
-        dataCapturingService = MovebisDataCapturingService(/*...,*/
-        uiListener, locationUpdateRate, customEventHandlingStrategy, capturingListener);
-    }
-}
-```
-
-* Create an account for synchronization & start WifiSurveyor
+Create an account for synchronization and start `WifiSurveyor`:
 
 ```java
 public class MainFragment extends Fragment implements ConnectionStatusListener {
     
-    @Nullable
     @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
             final Bundle savedInstanceState) {
         try {
             // dataCapturingService = ... - see above
             
-            // Needs to be called after DataCapturingService()
+            // Needs to be called after new CyfaceDataCapturingService()
             startSynchronization(context);
             
             // If you want to receive events for the synchronization status
@@ -159,40 +346,38 @@ public class MainFragment extends Fragment implements ConnectionStatusListener {
     }
 }
 ```
-          
-* Register your DataCapturingListener implementation and control data capturing
+
+#### De-/Register JWT Auth Tokens
+
+This is only required for `MovebisDataCapturingService`.
+
+#### Start/Stop UI Location Updates
+
+This is only required for `MovebisDataCapturingService`.
+
+### Control Capturing
+
+Now you can actually use the `DataCapturingService` instance to capture data.
+
+#### Start/Stop Capturing
+
+To capture a measurement you need to start the capturing and stop it after some time:
 
 ```java
-public class MainFragment extends Fragment {
-    
-    private DataCapturingButton dataCapturingButton;
-    
-    @Nullable
-    @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-        final Bundle savedInstanceState) {
-        this.dataCapturingButton = new DataCapturingButton();
-        
-        // dataCapturingService = ... - see above
-        
-        this.dataCapturingButton.setDataCapturingService(dataCapturingService);
-    }
-}
-
-public class DataCapturingButton implements AbstractButton, DataCapturingListener {
-    
-    @Override
+public class DataCapturingButton implements DataCapturingListener {
     public void onClick(View view) {
-        dataCapturingService.start(vehicle, new StartUpFinishedHandler(did) {
+        dataCapturingService.start(vehicle, new StartUpFinishedHandler(deviceId) {
             @Override
             public void startUpFinished(final long measurementIdentifier) {
+                // Your logic, e.g.:
                 setButtonStatus(button, true);
             }
         });
         // or
-        dataCapturingService.stop(new ShutDownFinishedHandler() {
+        dataCapturingService.stop(vehicle, new ShutDownFinishedHandler() {
             @Override
             public void shutDownFinished(final long measurementIdentifier) {
+                // Your logic, e.g.:
                 setButtonStatus(button, false);
                 setButtonEnabled(button);
             }
@@ -201,113 +386,92 @@ public class DataCapturingButton implements AbstractButton, DataCapturingListene
 }
 ```
 
-* To check if the capturing is running  
+#### Pause/Resume Capturing
+
+If you want to pause and continue a measurement you can use:
 
 ```java
-public class DataCapturingButton implements AbstractButton, DataCapturingListener {
+public class DataCapturingButton implements DataCapturingListener {
+    public void onClick(View view) {
+        dataCapturingService.pause(finishedHandler);
+        // or
+        dataCapturingService.resume(finishedHandler);
+    }
+}
+```
+
+### Access Measurements
+
+You now need to use the `PersistenceLayer` to access and control captured *measurement data*. 
+
+```java
+class measurementControlOrAccessClass {
     
-    public void onResume() {
-        if (dataCapturingService.reconnect(IS_RUNNING_CALLBACK_TIMEOUT)) {
-            setButtonStatus(button, true);
-        } else {
-            setButtonStatus(button, false);
+    PersistenceLayer<DefaultPersistenceBehaviour> persistence =
+        new PersistenceLayer<>(context, contentResolver, AUTHORITY, new DefaultPersistenceBehaviour());
+}
+```
+
+* Use `persistenceLayer.loadMeasurement(mid)` to load a specific measurement 
+* Use `loadMeasurements()` or `loadMeasurements(MeasurementStatus)` to load multiple measurements (of a specific state)
+
+Loaded `Measurement`s contain details, e.g. the [Measurement Distance](#load-measurement-distance).
+
+**Attention:** The attributes of a Measurement which is not yet finished change
+over time so you need to make sure you reload it.
+You can find an example for this in [Implement Data Capturing Listener](#implement-data-capturing-listener).
+
+#### Load Finished Measurements
+
+Finished measurements are measurements which are stopped (i.e. not paused or ongoing).
+
+```java
+class measurementControlOrAccessClass {
+    void loadMeasurements() {
+    
+        persistence.loadMeasurements(MeasurementStatus.FINISHED);
+    }
+}
+```
+
+#### Load Tracks
+
+The `loadTracks()` method returns a chronologically ordered list of `Track`s.
+
+Each time a measurement is paused and resumed, a new `Track` is started for the same measurement.
+
+A `Track` contains the chronologically ordered `GeoLocation`s captured.
+
+```java
+class measurementControlOrAccessClass {
+    void loadTrack() {
+        
+        List<Track> tracks = persistence.loadTracks(measurementId);
+        //noinspection StatementWithEmptyBody
+        if (tracks.size() > 0 ) {
+            // your logic
         }
     }
 }
 ```
 
-### Provide a Custom Capturing Notification
-To continuously run an Android service, without the system killing said service, it needs to show a notification to the user in the Android status bar.
-The Cyface data capturing runs as such a service and thus needs to display such a notification.
-Applications using the Cyface SDK may configure style and behaviour of this notification by providing an implementation of `de.cyface.datacapturing.EventHandlingStrategy` to the constructor of the `de.cyface.datacapturing.DataCapturingService`.
-An example implementation is provided by `de.cyface.datacapturing.IgnoreEventsStrategy`.
-The most important step is to implement the method `de.cyface.datacapturing.EventHandlingStrategy#buildCapturingNotification(DataCapturingBackgroundService)`.
-
-This can look like:
-
-```java
-public class EventHandlingStrategyImpl implements EventHandlingStrategy {
-    
-    @Override
-    public @NonNull Notification buildCapturingNotification(final @NonNull DataCapturingBackgroundService context) {
-      final String channelId = "channel";
-      NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O && notificationManager.getNotificationChannel(channelId)==null) {
-        final NotificationChannel channel = new NotificationChannel(channelId, "Cyface Data Capturing", NotificationManager.IMPORTANCE_DEFAULT);
-        notificationManager.createNotificationChannel(channel);
-      }
-    
-      return new NotificationCompat.Builder(context, channelId)
-        .setContentTitle("Cyface")
-        .setSmallIcon(R.drawable.your_icon) // see "attention" notes below
-        .setContentText("Running Data Capturing")
-        .setOngoing(true)
-        .setAutoCancel(false)
-        .build();
-    }
-}
-```
-
-Further details about how to create a proper notification are available via the [Google developer documentation](https://developer.android.com/guide/topics/ui/notifiers/notifications).
-The most likely adaptation an application using the Cyface SDK for Android should do, is use the `android.app.Notification.Builder.setContentIntent(PendingIntent)` to call the applications main activity if the user presses the notification.
-
-**ATTENTION:**
-* Service notifications require an application wide unique identifier.
-  This identifier is 74.656.
-  Due to limitations in the Android framework, this is not configurable.
-  You must not use the same notification identifier for any other notification displayed by your app!
-* If you want to use a **vector xml drawable as Notification icon** make sure to do the follwing:
-  Even with `vectorDrawables.useSupportLibrary` enabled the vector drawable won't work as a notification icon (`notificationBuilder.setSmallIcon()`)
-  on devices with API < 21. We assume that's because of the way we need to inject your custom notification.
-  A simple fix is to have a the xml in `drawable-anydpi-v21/icon.xml` and to generate notification icon PNGs under the same name in the usual paths (`drawable-**dpi/icon.png`). 
-  
-
-
-
-### Access Measurements via PersistenceLayer
-Use the `PersistenceLayer<DefaultPersistenceBehaviour>` to manage and load measurements as demonstrated in the sample code below.
-
-* Use `persistenceLayer.loadMeasurement(mid)` to load a specific measurement 
-* Use `loadMeasurements()` or `loadMeasurements(MeasurementStatus)` to load multiple measurements (of a specific state)
-                                                              
-#### Load Measurements
-                                                              
-**ATTENTION:** The attributes of `MeasurementStatus#OPEN` and `MeasurementStatus#PAUSED`
-measurements are only valid in the moment they are loaded from the database. Changes
-after this call are not pushed into the `Measurement` object returned by this call.
-
-**Measurement distance**
+#### Load Measurement Distance
 
 To display the distance for an ongoing measurement (which is updated about once per second)
 make sure to call `persistenceLayer.loadCurrentlyCapturedMeasurement()` *on each location
 update* to always have the most recent information. For this you need to implement the `DataCapturingListener`
 interface to be notified on `onNewGeoLocationAcquired(GeoLocation)` events.
 
-**Load Track**
-
-To display the track of a finished measurement use `persistenceLayer.loadTrack(measurementId)`
-which returns a list of lists containing `GeoLocations`. Currently there is always just one
-sub list which contains the full track. We'll change this soon so that tracks are sliced into sub tracks
-when pause/resume was used which is the reason behind the return type. 
+See [Implement Data Capturing Listener](#implement-data-capturing-listener) for sample code.
 
 #### Delete Measurements
 
-The following code snippet shows how to manage stored measurements:
+To delete the measurement data stored on the device for finished or synchronized measurements use:
 
 ```java
-public class MeasurementOverviewFragment extends Fragment {
+class measurementControlOrAccessClass {
     
-    private PersistenceLayer<DefaultPersistenceBehaviour> persistenceLayer;
-    
-    @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-            final Bundle savedInstanceState) {
-        persistenceLayer = new PersistenceLayer<>(inflater.getContext(), inflater.getContext().getContentResolver(),
-                AUTHORITY, new DefaultPersistenceBehaviour());
-    }
-    
-    private void deleteMeasurement(final long measurementId) throws CursorIsNullException {
-        
+    void deleteMeasurement(final long measurementId) throws CursorIsNullException {
         // To make sure you don't delete the ongoing measurement because this leads to an exception
         Measurement currentlyCapturedMeasurement;
         try {
@@ -323,7 +487,7 @@ public class MeasurementOverviewFragment extends Fragment {
             Log.d(TAG, "Not deleting currently captured measurement: " + measurementId);
         }
     }
-
+    
     private static class DeleteFromDBTaskParams {
         final PersistenceLayer<DefaultPersistenceBehaviour> persistenceLayer;
         final long measurementId;
@@ -349,19 +513,24 @@ public class MeasurementOverviewFragment extends Fragment {
 }
 ```
 
-### TODO: add code sample for the usage of:
+
+### Documentation Incomplete
+
+This documentation still lacks of samples for the following features:
 
 * ErrorHandler
 * Force Synchronization
 * ConnectionStatusListener
 * Disable synchronization
-* Show Measurements and GeoLocationTraces
-* Usage of Camera, Bluetooth
+* Enable synchronization on metered connections
+* Usage of Camera, Bluetooth (not yet implemented in the SDK)
+
 
 Migration from Earlier Versions
 --------------------------------
  - [Migrate to 4.0.0-alpha2](documentation/migration-guide_4.0.0-alpha2.md)
  - [Migrate to 4.0.0-alpha1](documentation/migration-guide_4.0.0-alpha1.md)
+
 
 License
 -------------------

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -70,7 +70,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.4.0
+ * @version 5.4.1
  * @since 1.0.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -301,6 +301,8 @@ public class CapturedDataWriterTest {
 
         final int testMeasurementsWithPoint3dFiles = 1;
         final int point3dFilesPerMeasurement = 3;
+        final int testEvents = 2;
+        oocut.logEvent(Event.EventType.LIFECYCLE_START, measurement);
         capturingBehaviour.storeData(testData(), measurement.getIdentifier(), finishedCallback);
 
         // Store PointMetaData
@@ -308,6 +310,7 @@ public class CapturedDataWriterTest {
                 MeasurementSerializer.PERSISTENCE_FILE_FORMAT_VERSION), measurement.getIdentifier());
 
         capturingBehaviour.storeLocation(testLocation(1L), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_STOP, measurement);
 
         lock.lock();
         try {
@@ -323,7 +326,7 @@ public class CapturedDataWriterTest {
         // final int testIdentifierTableCount = 1; - currently not deleted at the end of tests because this breaks
         // the life-cycle DataCapturingServiceTests
         assertThat(removedEntries, is(equalTo(testMeasurementsWithPoint3dFiles * point3dFilesPerMeasurement
-                + TEST_LOCATION_COUNT + testMeasurements /* + testIdentifierTableCount */)));
+                + TEST_LOCATION_COUNT + testMeasurements /* + testIdentifierTableCount */ + testEvents)));
 
         // make sure nothing is left in the database
         Cursor geoLocationsCursor = null;

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -70,7 +70,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.3.6
+ * @version 5.4.0
  * @since 1.0.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -55,6 +55,7 @@ import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.PointMetaData;
+import de.cyface.persistence.model.Track;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.persistence.serialization.MeasurementSerializer;
 import de.cyface.persistence.serialization.Point3dFile;
@@ -239,7 +240,7 @@ public class CapturedDataWriterTest {
             lock.unlock();
         }
 
-        capturingBehaviour.storeLocation(testLocation(), measurement.getIdentifier());
+        capturingBehaviour.storeLocation(testLocation(1L), measurement.getIdentifier());
 
         // Check if the captured data was persisted
         Cursor geoLocationsCursor = null;
@@ -306,7 +307,7 @@ public class CapturedDataWriterTest {
         oocut.storePointMetaData(new PointMetaData(TEST_DATA_COUNT, TEST_DATA_COUNT, TEST_DATA_COUNT,
                 MeasurementSerializer.PERSISTENCE_FILE_FORMAT_VERSION), measurement.getIdentifier());
 
-        capturingBehaviour.storeLocation(testLocation(), measurement.getIdentifier());
+        capturingBehaviour.storeLocation(testLocation(1L), measurement.getIdentifier());
 
         lock.lock();
         try {
@@ -419,7 +420,7 @@ public class CapturedDataWriterTest {
         } finally {
             lock.unlock();
         }
-        capturingBehaviour.storeLocation(testLocation(), measurement.getIdentifier());
+        capturingBehaviour.storeLocation(testLocation(1L), measurement.getIdentifier());
         oocut.logEvent(Event.EventType.LIFECYCLE_STOP, measurement);
 
         // Act
@@ -453,11 +454,9 @@ public class CapturedDataWriterTest {
 
         Cursor eventsCursor = null;
         try {
-            eventsCursor = mockResolver.query(getEventUri(AUTHORITY), null,
-                    EventTable.COLUMN_MEASUREMENT_FK + "=?",
+            eventsCursor = mockResolver.query(getEventUri(AUTHORITY), null, EventTable.COLUMN_MEASUREMENT_FK + "=?",
                     new String[] {Long.valueOf(measurement.getIdentifier()).toString()}, null);
-            Validate.notNull("Test failed because it was unable to load data from the content provider.",
-                    eventsCursor);
+            Validate.notNull("Test failed because it was unable to load data from the content provider.", eventsCursor);
 
             assertThat(eventsCursor.getCount(), is(equalTo(0)));
         } finally {
@@ -475,14 +474,144 @@ public class CapturedDataWriterTest {
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
     @Test
-    public void testLoadTrack() throws CursorIsNullException {
-        Measurement measurement = oocut.newMeasurement(Vehicle.UNKNOWN);
-        capturingBehaviour.storeLocation(testLocation(), measurement.getIdentifier());
-        List<Measurement> measurements = oocut.loadMeasurements();
-        assertThat(measurements.size(), is(equalTo(1)));
-        for (Measurement loadedMeasurement : measurements) {
-            assertThat(oocut.loadTracks(loadedMeasurement.getIdentifier()).get(0).getGeoLocations().size(), is(equalTo(1)));
-        }
+    public void testLoadTrack_startPauseResumeStop() throws CursorIsNullException {
+
+        // Arrange
+        final Measurement measurement = oocut.newMeasurement(Vehicle.UNKNOWN);
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_START, measurement);
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_PAUSE, measurement);
+        // It's possible that GeoLocations arrive just after capturing was paused
+        final long timestamp3 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp3), measurement.getIdentifier());
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_RESUME, measurement);
+        final long timestamp4 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp4), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_STOP, measurement);
+        // It's possible that GeoLocations arrive just after stop method was triggered
+        final long timestamp5 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp5), measurement.getIdentifier());
+
+        // Act
+        final List<Measurement> loadedMeasurements = oocut.loadMeasurements();
+        assertThat(loadedMeasurements.size(), is(equalTo(1)));
+        List<Track> tracks = oocut.loadTracks(loadedMeasurements.get(0).getIdentifier());
+
+        // Assert
+        assertThat(tracks.size(), is(equalTo(2)));
+        assertThat(tracks.get(0).getGeoLocations().size(), is(equalTo(3)));
+        assertThat(tracks.get(1).getGeoLocations().size(), is(equalTo(2)));
+        assertThat(tracks.get(0).getGeoLocations().get(2).getTimestamp(), is(equalTo(timestamp3)));
+        assertThat(tracks.get(1).getGeoLocations().get(0).getTimestamp(), is(equalTo(timestamp4)));
+        assertThat(tracks.get(1).getGeoLocations().get(1).getTimestamp(), is(equalTo(timestamp5)));
+    }
+
+    /**
+     * Tests whether loading a track of geo locations is possible via the {@link PersistenceLayer} object.
+     *
+     * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
+     */
+    @Test
+    public void testLoadTrack_startPauseResumePauseStop() throws CursorIsNullException {
+
+        // Arrange
+        final Measurement measurement = oocut.newMeasurement(Vehicle.UNKNOWN);
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_START, measurement);
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_PAUSE, measurement);
+        // It's possible that GeoLocations arrive just after capturing was paused
+        final long timestamp3 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp3), measurement.getIdentifier());
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_RESUME, measurement);
+        final long timestamp4 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp4), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_PAUSE, measurement);
+        // It's possible that GeoLocations arrive just after pause method was triggered
+        final long timestamp5 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp5), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_STOP, measurement);
+        // It's possible that GeoLocations arrive just after stop method was triggered
+        final long timestamp6 = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp6), measurement.getIdentifier());
+
+        // Act
+        final List<Measurement> loadedMeasurements = oocut.loadMeasurements();
+        assertThat(loadedMeasurements.size(), is(equalTo(1)));
+        List<Track> tracks = oocut.loadTracks(loadedMeasurements.get(0).getIdentifier());
+
+        // Assert
+        assertThat(tracks.size(), is(equalTo(2)));
+        assertThat(tracks.get(0).getGeoLocations().size(), is(equalTo(3)));
+        assertThat(tracks.get(1).getGeoLocations().size(), is(equalTo(3)));
+        assertThat(tracks.get(1).getGeoLocations().get(1).getTimestamp(), is(equalTo(timestamp5)));
+        assertThat(tracks.get(1).getGeoLocations().get(2).getTimestamp(), is(equalTo(timestamp6)));
+    }
+
+    /**
+     * Tests whether loading a track of geo locations is possible via the {@link PersistenceLayer} object.
+     *
+     * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
+     */
+    @Test
+    public void testLoadTrack_startPauseStop() throws CursorIsNullException {
+
+        // Arrange
+        final Measurement measurement = oocut.newMeasurement(Vehicle.UNKNOWN);
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_START, measurement);
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_PAUSE, measurement);
+        // It's possible that GeoLocations arrive just after capturing was paused
+        final long timestamp = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp), measurement.getIdentifier());
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_STOP, measurement);
+
+        // Act
+        final List<Measurement> loadedMeasurements = oocut.loadMeasurements();
+        assertThat(loadedMeasurements.size(), is(equalTo(1)));
+        List<Track> tracks = oocut.loadTracks(loadedMeasurements.get(0).getIdentifier());
+
+        // Assert
+        assertThat(tracks.size(), is(equalTo(1)));
+        assertThat(tracks.get(0).getGeoLocations().size(), is(equalTo(3)));
+        assertThat(tracks.get(0).getGeoLocations().get(2).getTimestamp(), is(equalTo(timestamp)));
+    }
+
+    /**
+     * Tests whether loading a track of geo locations is possible via the {@link PersistenceLayer} object.
+     *
+     * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
+     */
+    @Test
+    public void testLoadTrack_startStop() throws CursorIsNullException {
+
+        // Arrange
+        final Measurement measurement = oocut.newMeasurement(Vehicle.UNKNOWN);
+
+        oocut.logEvent(Event.EventType.LIFECYCLE_START, measurement);
+        capturingBehaviour.storeLocation(testLocation(System.currentTimeMillis()), measurement.getIdentifier());
+        oocut.logEvent(Event.EventType.LIFECYCLE_STOP, measurement);
+        // It's possible that GeoLocations arrive just after stop method was triggered
+        final long timestamp = System.currentTimeMillis();
+        capturingBehaviour.storeLocation(testLocation(timestamp), measurement.getIdentifier());
+
+        // Act
+        final List<Measurement> loadedMeasurements = oocut.loadMeasurements();
+        assertThat(loadedMeasurements.size(), is(equalTo(1)));
+        List<Track> tracks = oocut.loadTracks(loadedMeasurements.get(0).getIdentifier());
+
+        // Assert
+        assertThat(tracks.size(), is(equalTo(1)));
+        assertThat(tracks.get(0).getGeoLocations().size(), is(equalTo(2)));
+        assertThat(tracks.get(0).getGeoLocations().get(1).getTimestamp(), is(equalTo(timestamp)));
     }
 
     @Test
@@ -509,10 +638,11 @@ public class CapturedDataWriterTest {
     }
 
     /**
-     * @return An initialized {@link GeoLocation} object with garbage data for testing.
+     * @param timestamp The timestamp in milliseconds since 1970 to use for the {@link GeoLocation}
+     * @return An initialized {@code GeoLocation} object with garbage data for testing.
      */
-    private GeoLocation testLocation() {
-        return new GeoLocation(1.0, 1.0, 1L, 1.0, 1);
+    private GeoLocation testLocation(final long timestamp) {
+        return new GeoLocation(1.0, 1.0, timestamp, 1.0, 1);
     }
 
     /**

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -460,7 +460,7 @@ public class CapturedDataWriterTest {
         List<Measurement> measurements = oocut.loadMeasurements();
         assertThat(measurements.size(), is(equalTo(1)));
         for (Measurement loadedMeasurement : measurements) {
-            assertThat(oocut.loadTracks(loadedMeasurement.getIdentifier()).get(0).size(), is(equalTo(1)));
+            assertThat(oocut.loadTracks(loadedMeasurement.getIdentifier()).get(0).getGeoLocations().size(), is(equalTo(1)));
         }
     }
 

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -460,7 +460,7 @@ public class CapturedDataWriterTest {
         List<Measurement> measurements = oocut.loadMeasurements();
         assertThat(measurements.size(), is(equalTo(1)));
         for (Measurement loadedMeasurement : measurements) {
-            assertThat(oocut.loadTrack(loadedMeasurement.getIdentifier()).get(0).size(), is(equalTo(1)));
+            assertThat(oocut.loadTracks(loadedMeasurement.getIdentifier()).get(0).size(), is(equalTo(1)));
         }
     }
 

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -68,7 +68,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.2.8
+ * @version 5.3.0
  * @since 2.0.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -2,6 +2,7 @@ package de.cyface.datacapturing;
 
 import static de.cyface.datacapturing.TestUtils.ACCOUNT_TYPE;
 import static de.cyface.datacapturing.TestUtils.AUTHORITY;
+import static de.cyface.persistence.Utils.getEventUri;
 import static de.cyface.persistence.model.MeasurementStatus.FINISHED;
 import static de.cyface.persistence.model.MeasurementStatus.OPEN;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -10,6 +11,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -27,7 +29,9 @@ import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
 import android.content.ContentProvider;
+import android.content.ContentResolver;
 import android.content.Context;
+import android.database.Cursor;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.FlakyTest;
@@ -44,9 +48,11 @@ import de.cyface.datacapturing.exception.SetupException;
 import de.cyface.datacapturing.persistence.CapturingPersistenceBehaviour;
 import de.cyface.datacapturing.ui.UIListener;
 import de.cyface.persistence.DefaultPersistenceBehaviour;
+import de.cyface.persistence.EventTable;
 import de.cyface.persistence.MeasuringPointsContentProvider;
 import de.cyface.persistence.NoSuchMeasurementException;
 import de.cyface.persistence.PersistenceLayer;
+import de.cyface.persistence.model.Event;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Vehicle;
@@ -655,7 +661,7 @@ public class DataCapturingServiceTest {
     }
 
     /**
-     * Tests if the service lifecycle is running successfully.
+     * Tests if the service lifecycle is running successfully and that the life-cycle {@link Event}s are logged.
      * <p>
      * Makes sure the {@link DataCapturingService#pause(ShutDownFinishedHandler)} and
      * {@link DataCapturingService#resume(StartUpFinishedHandler)} work correctly.
@@ -680,6 +686,34 @@ public class DataCapturingServiceTest {
         assertThat(measurements.size() == newMeasurements.size(), is(equalTo(true)));
 
         stopAndCheckThatStopped(measurementIdentifier);
+
+        // Check Events
+        ContentResolver contentResolver = context.getContentResolver();
+        Cursor eventCursor = null;
+        try {
+            eventCursor = contentResolver.query(getEventUri(AUTHORITY), null, EventTable.COLUMN_MEASUREMENT_FK + "=?",
+                    new String[] {Long.valueOf(measurementIdentifier).toString()},
+                    EventTable.COLUMN_TIMESTAMP + " ASC");
+            Validate.softCatchNullCursor(eventCursor);
+
+            final List<Event> events = new ArrayList<>();
+            while (eventCursor.moveToNext()) {
+                final Event.EventType eventType = Event.EventType
+                        .valueOf(eventCursor.getString(eventCursor.getColumnIndex(EventTable.COLUMN_TYPE)));
+                final long eventTime = eventCursor.getLong(eventCursor.getColumnIndex(EventTable.COLUMN_TIMESTAMP));
+                events.add(new Event(eventType, eventTime));
+            }
+
+            assertThat(events.size(), is(equalTo(4)));
+            assertThat(events.get(0).getType(), is(equalTo(Event.EventType.LIFECYCLE_START)));
+            assertThat(events.get(1).getType(), is(equalTo(Event.EventType.LIFECYCLE_PAUSE)));
+            assertThat(events.get(2).getType(), is(equalTo(Event.EventType.LIFECYCLE_RESUME)));
+            assertThat(events.get(3).getType(), is(equalTo(Event.EventType.LIFECYCLE_STOP)));
+        } finally {
+            if (eventCursor != null) {
+                eventCursor.close();
+            }
+        }
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -119,7 +119,7 @@ public abstract class DataCapturingService {
     /**
      * A facade object providing access to the data stored by this <code>DataCapturingService</code>.
      */
-    protected final PersistenceLayer<CapturingPersistenceBehaviour> persistenceLayer;
+    final PersistenceLayer<CapturingPersistenceBehaviour> persistenceLayer;
     /**
      * Messenger that handles messages arriving from the <code>DataCapturingBackgroundService</code>.
      */
@@ -169,6 +169,7 @@ public abstract class DataCapturingService {
     /**
      * The number of ms to wait for the callback, see {@link #isRunning(long, TimeUnit, IsRunningCallback)}.
      */
+    @SuppressWarnings("WeakerAccess") // Used by SDK integrators (CY)
     public final static long IS_RUNNING_CALLBACK_TIMEOUT = 500L;
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -92,7 +92,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 14.0.2
+ * @version 14.0.3
  * @since 1.0.0
  */
 public abstract class DataCapturingService {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -119,7 +119,7 @@ public abstract class DataCapturingService {
     /**
      * A facade object providing access to the data stored by this <code>DataCapturingService</code>.
      */
-    final PersistenceLayer<CapturingPersistenceBehaviour> persistenceLayer;
+    protected final PersistenceLayer<CapturingPersistenceBehaviour> persistenceLayer;
     /**
      * Messenger that handles messages arriving from the <code>DataCapturingBackgroundService</code>.
      */

--- a/datacapturing/src/main/java/de/cyface/datacapturing/EventHandlingStrategy.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/EventHandlingStrategy.java
@@ -31,7 +31,7 @@ import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.0.1
+ * @version 2.0.2
  * @since 2.5.0
  */
 public interface EventHandlingStrategy extends Parcelable {
@@ -46,6 +46,14 @@ public interface EventHandlingStrategy extends Parcelable {
 
     /**
      * Provides an Android representation of a {@code Notification}, that can be displayed on screen.
+     * <p>
+     * <b>Attention:</b>
+     * If you want to use a **vector xml drawable as Notification icon** make sure to do the following:
+     * Even with `vectorDrawables.useSupportLibrary` enabled the vector drawable won't work as a notification icon
+     * (`notificationBuilder.setSmallIcon()`) on devices with API < 21.
+     * We assume that's because of the way we need to inject your custom notification.
+     * A simple fix is to have a the xml in `res/drawable-anydpi-v21/icon.xml` and to generate notification icon PNGs
+     * under the same resource name in the usual paths (`res/drawable-**dpi/icon.png`).
      *
      * @param context The {@link DataCapturingBackgroundService} as context for the new {@code Notification}.
      * @return An Android {@code Notification} object configured to work as capturing notification.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -165,6 +165,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         if (locationStatusHandler.hasLocationFix()) {
             double latitude = location.getLatitude();
             double longitude = location.getLongitude();
+            // FIXME: How do know if the gps-time is aligned with the sensor(end event) timestamps which are basically the System time?
             long locationTime = location.getTime();
             double speed = getCurrentSpeed(location);
             float locationAccuracy = location.getAccuracy();

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -34,7 +34,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.3.7
+ * @version 1.3.8
  * @since 1.0.0
  */
 public abstract class CapturingProcess implements SensorEventListener, LocationListener, Closeable {
@@ -165,7 +165,6 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         if (locationStatusHandler.hasLocationFix()) {
             double latitude = location.getLatitude();
             double longitude = location.getLongitude();
-            // FIXME: How do know if the gps-time is aligned with the sensor(end event) timestamps which are basically the System time?
             long locationTime = location.getTime();
             double speed = getCurrentSpeed(location);
             float locationAccuracy = location.getAccuracy();

--- a/documentation/migration-guide_4.0.0-alpha1.md
+++ b/documentation/migration-guide_4.0.0-alpha1.md
@@ -1,6 +1,6 @@
 # Cyface Android SDK 4.0.0-alpha1 Migration Guide
 
-This migration guide is written for apps using the `MovebisDataCapturinService`.
+This migration guide is written for apps using the `MovebisDataCapturingService`.
 
 If you use the `CyfaceDataCapturingService` instead, please contact us. 
 
@@ -27,15 +27,7 @@ If you use the `CyfaceDataCapturingService` instead, please contact us.
 
 #### Implement Data Capturing Listener
 
-*No API changes.*
-
-#### Implement UI Listener
-
-*No API changes.*
-
-#### Implement Event Handling Strategy
-
-The API of the `EventHandlingStrategy` interface did not change but we added a new the feature
+The API of the `DataCapturingListener` interface did not change but we added a new the feature
 to get the measurement distance. To do so during an *ongoing* capturing you need to re-load
 the distance when new `GeoLocation`s are captured: 
 
@@ -60,6 +52,14 @@ class DataCapturingListenerImpl implements DataCapturingListener {
     }
 }
 ```
+
+#### Implement UI Listener
+
+*No API changes.*
+
+#### Implement Event Handling Strategy
+
+*No API changes.*
 
 #### Start Service
 

--- a/documentation/migration-guide_4.0.0-alpha1.md
+++ b/documentation/migration-guide_4.0.0-alpha1.md
@@ -224,3 +224,4 @@ class measurementControlOrAccessClass {
         persistence.delete(measurementId);
     }
 }
+```

--- a/documentation/migration-guide_4.0.0-alpha2.md
+++ b/documentation/migration-guide_4.0.0-alpha2.md
@@ -1,0 +1,110 @@
+# Cyface Android SDK 4.0.0-alpha2 Migration Guide
+
+This migration guide is written for apps using the `MovebisDataCapturinService`.
+
+If you use the `CyfaceDataCapturingService` instead, please contact us. 
+
+## Upgrading from 4.0.0-alpha1
+
+If you want to migrate from an earlier version please start with the [previous migration guide](./migration-guide_4.0.0-alpha1.md).
+
+- [Service Initialization](#service-initialization)
+	- [Implement Data Capturing Listener](#implement-data-capturing-listener)
+	- [Implement UI Listener](#implement-ui-listener)
+	- [Implement Event Handling Strategy](#implement-event-handling-strategy)
+	- [Start Service](#start-service)
+	- [Reconnect to Service](#reconnect-to-service)
+	- [De-/Register JWT Auth Tokens](#de-register-jwt-auth-tokens)
+	- [Start/Stop UI Location Updates](#startstop-ui-location-updates)
+- [Control Capturing](#control-capturing)
+	- [Start/Stop Capturing](#startstop-capturing)
+	- [Pause/Resume Capturing](#pauseresume-capturing)
+- [Access Measurements](#access-measurements)
+	- [Load finished measurements](#load-finished-measurements)
+	- [Load Tracks](#load-tracks)
+	- [Load Measurement Distance (new feature)](#load-measurement-distance)
+	- [Delete Measurements](#delete-measurements)
+
+### Service Initialization
+
+#### Implement Data Capturing Listener
+
+*No API changes.*
+
+#### Implement UI Listener
+
+*No API changes.*
+
+#### Implement Event Handling Strategy
+
+*No API changes.*
+
+#### Start Service
+
+*No API changes.*
+
+#### Reconnect to Service
+
+*No API changes.*
+
+#### De-/Register JWT Auth Tokens
+
+*No API changes.*
+
+#### Start/Stop UI Location Updates
+
+*No API changes.*
+
+### Control Capturing
+
+#### Start/Stop Capturing
+
+*No API changes.*
+
+#### Pause/Resume Capturing
+
+*No API changes.*
+
+### Access Measurements
+
+*No API changes.*
+
+#### Load Finished Measurements
+
+*No API changes.*
+
+#### Load Tracks
+
+In the last version we returned the full track as the first sub list.
+Now we implemented the "slicing" of the track into sub `Track`s (sliced before resume events). 
+I.e. the `loadTracks()` method now returns a list of chronologically ordered `Track`s, each containing chronologically ordered `GeoLocation`s.
+
+Use the `PersistenceLayer` to access data, see [Access Measurements](#access-measurements).
+
+```java
+class measurementControlOrAccessClass {
+    void loadTrack() {
+        
+        // Version 4.0.0-alpha1
+        List<List<GeoLocation>> tracks = persistence.loadTrack(measurementId);
+        if (tracks.size() > 0 ) {
+            List<GeoLocation> fullTrack = tracks.get(0);
+        }
+        
+        // Version 4.0.0-alpha2
+        List<Track> tracks = persistence.loadTracks(measurementId);
+        //noinspection StatementWithEmptyBody
+        if (tracks.size() > 0 ) {
+            // your logic
+        }
+    }
+}
+```
+
+#### Load Measurement Distance
+
+*No API changes.*
+
+#### Delete Measurements
+
+*No API changes.*

--- a/documentation/migration-guide_4.0.0-alpha2.md
+++ b/documentation/migration-guide_4.0.0-alpha2.md
@@ -1,19 +1,27 @@
-# Cyface Android SDK 4.0.0-alpha2 Migration Guide
+Cyface Android SDK 4.0.0-alpha2 Migration Guide
+=================================================
 
 This migration guide is written for apps using the `MovebisDataCapturinService`.
 
 If you use the `CyfaceDataCapturingService` instead, please contact us. 
 
-## Upgrading from 4.0.0-alpha1
+Upgrading from 4.0.0-alpha1
+-------------------------------
 
 If you want to migrate from an earlier version please start with the [previous migration guide](./migration-guide_4.0.0-alpha1.md).
 
+- [Resource Files](#resource-files)
+    - [Truststore](#truststore)
+    - [Content Provider Authority](#content-provider-authority)
 - [Service Initialization](#service-initialization)
 	- [Implement Data Capturing Listener](#implement-data-capturing-listener)
 	- [Implement UI Listener](#implement-ui-listener)
 	- [Implement Event Handling Strategy](#implement-event-handling-strategy)
+	    - [Custom Capturing Notification](#custom-capturing-notification)
 	- [Start Service](#start-service)
 	- [Reconnect to Service](#reconnect-to-service)
+	- [Link your Login Activity](#link-your-login-activity)
+	- [Start WifiSurveyor](#start-wifisurveyor)
 	- [De-/Register JWT Auth Tokens](#de-register-jwt-auth-tokens)
 	- [Start/Stop UI Location Updates](#startstop-ui-location-updates)
 - [Control Capturing](#control-capturing)
@@ -24,6 +32,17 @@ If you want to migrate from an earlier version please start with the [previous m
 	- [Load Tracks](#load-tracks)
 	- [Load Measurement Distance (new feature)](#load-measurement-distance)
 	- [Delete Measurements](#delete-measurements)
+
+### Resource Files
+
+#### Truststore
+
+*No API changes.*
+
+#### Content Provider Authority
+
+The API did not change but we updated the [README](../README.md) to clarify where exactly you need
+to set the [Content Provider Authority](../README.md#content-provider-authority).
 
 ### Service Initialization
 
@@ -37,13 +56,48 @@ If you want to migrate from an earlier version please start with the [previous m
 
 #### Implement Event Handling Strategy
 
-*No API changes.*
+*No API changes*
+
+##### Custom Capturing Notification
+
+We noticed the following:
+  
+* If you want to use a **vector xml drawable as Notification icon** make sure to do the following:
+
+  Even with `vectorDrawables.useSupportLibrary` enabled the vector drawable won't work as a notification icon (`notificationBuilder.setSmallIcon()`)
+  on devices with API < 21. We assume that's because of the way we need to inject your custom notification.
+  A simple fix is to have a the xml in `res/drawable-anydpi-v21/icon.xml` and to generate notification icon PNGs under the same resource name in the usual paths (`res/drawable-**dpi/icon.png`).
+
+```java
+class EventHandlingStrategyImpl implements EventHandlingStrategy {
+
+    public Notification buildCapturingNotification(@NonNull final DataCapturingBackgroundService context) {
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId)
+                .setContentTitle(context.getText(de.cyface.datacapturing.R.string.capturing_active))
+                .setContentIntent(onClickPendingIntent).setWhen(System.currentTimeMillis()).setOngoing(true)
+                .setAutoCancel(false);
+    
+        // This leads to the crash if you only have a vector drawable in the resources
+        builder.setSmallIcon(R.drawable.icon);
+        return builder.build();
+    }
+}
+```
 
 #### Start Service
 
 *No API changes.*
 
 #### Reconnect to Service
+
+*No API changes.*
+
+#### Link your Login Activity
+
+*No API changes.*
+
+#### Start WifiSurveyor
 
 *No API changes.*
 

--- a/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
+++ b/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
@@ -25,7 +25,7 @@ import de.cyface.persistence.serialization.Point3dFile;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.3.2
+ * @version 4.3.3
  * @since 1.0.0
  */
 class DatabaseHelper extends SQLiteOpenHelper {
@@ -38,7 +38,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
      * Increase the DATABASE_VERSION if the database structure changes with a new update
      * but don't forget to adjust onCreate and onUpgrade accordingly for the new structure and incremental upgrade
      */
-    private final static int DATABASE_VERSION = 11;
+    private final static int DATABASE_VERSION = 12;
     /**
      * The table containing all the measurements, without the corresponding data. Data is stored in one table per type.
      */

--- a/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
+++ b/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
@@ -26,7 +26,7 @@ import de.cyface.persistence.serialization.Point3dFile;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.3.3
+ * @version 4.4.0
  * @since 1.0.0
  */
 class DatabaseHelper extends SQLiteOpenHelper {

--- a/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
+++ b/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
@@ -15,6 +15,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import de.cyface.persistence.model.Event;
 import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.serialization.Point3dFile;
@@ -52,6 +53,10 @@ class DatabaseHelper extends SQLiteOpenHelper {
      * id count is reset, too.
      */
     private final IdentifierTable identifierTable;
+    /**
+     * The table to store the {@link Event}s on the device.
+     */
+    private final EventTable eventTable;
 
     /**
      * Creates a new completely initialized <code>DatabaseHelper</code>.
@@ -65,6 +70,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         measurementTable = new MeasurementTable();
         geoLocationsTable = new GeoLocationsTable();
         identifierTable = new IdentifierTable();
+        eventTable = new EventTable();
     }
 
     /**
@@ -78,6 +84,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         identifierTable.onCreate(db);
         measurementTable.onCreate(db);
         geoLocationsTable.onCreate(db);
+        eventTable.onCreate(db);
     }
 
     /**
@@ -119,6 +126,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         measurementTable.onUpgrade(database, oldVersion, newVersion);
         geoLocationsTable.onUpgrade(database, oldVersion, newVersion);
         identifierTable.onUpgrade(database, oldVersion, newVersion);
+        eventTable.onUpgrade(database, oldVersion, newVersion);
     }
 
     /**
@@ -165,6 +173,10 @@ class DatabaseHelper extends SQLiteOpenHelper {
                 }
             } else if (pathSegments.size() == 1) {
                 switch (pathSegments.get(0)) {
+                    case EventTable.URI_PATH:
+                        ret += table.deleteRow(getWritableDatabase(), selection, selectionArgs);
+                        database.setTransactionSuccessful();
+                        return ret;
                     case IdentifierTable.URI_PATH:
                         ret += table.deleteRow(getWritableDatabase(), selection, selectionArgs);
                         database.setTransactionSuccessful();
@@ -201,8 +213,8 @@ class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     /**
-     * Cascadingly deletes all data for a single {@link Measurement} from the database. This currently only includes
-     * {@link GeoLocation}s but not the {@link Point3dFile}s as they are not stored in database.
+     * Cascadingly deletes all data for a single {@link Measurement} from the database. This only includes
+     * {@link GeoLocation}s and {@link Event}s but not the {@link Point3dFile}s as they are not stored in database.
      *
      * @param database The database object to delete from.
      * @param measurementIdentifier The device wide unique identifier of the measurement to delete.
@@ -213,6 +225,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         int ret = 0;
 
         ret += geoLocationsTable.deleteRow(database, GeoLocationsTable.COLUMN_MEASUREMENT_FK + "=?", identifierAsArgs);
+        ret += eventTable.deleteRow(database, EventTable.COLUMN_MEASUREMENT_FK + "=?", identifierAsArgs);
         return ret;
     }
 
@@ -328,6 +341,8 @@ class DatabaseHelper extends SQLiteOpenHelper {
                 return geoLocationsTable;
             case IdentifierTable.URI_PATH:
                 return identifierTable;
+            case EventTable.URI_PATH:
+                return eventTable;
             default:
                 throw new IllegalStateException("Unknown table with URI: " + uri);
         }

--- a/persistence/src/main/java/de/cyface/persistence/EventTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/EventTable.java
@@ -41,7 +41,7 @@ public class EventTable extends AbstractCyfaceMeasurementTable {
      * Provides a completely initialized object as a representation of a table containing {@link Event}s in the
      * database.
      */
-    protected EventTable() {
+    EventTable() {
         super(URI_PATH);
     }
 

--- a/persistence/src/main/java/de/cyface/persistence/EventTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/EventTable.java
@@ -1,0 +1,77 @@
+package de.cyface.persistence;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.provider.BaseColumns;
+
+import de.cyface.persistence.model.Event;
+import de.cyface.persistence.model.Measurement;
+
+/**
+ * Table for storing {@link Event}s.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.0
+ */
+public class EventTable extends AbstractCyfaceMeasurementTable {
+
+    /**
+     * The path segment in the table URI identifying the {@link EventTable}.
+     */
+    final static String URI_PATH = "events";
+    /**
+     * Column name for the column storing the {@link Event} timestamp.
+     */
+    public static final String COLUMN_TIMESTAMP = "timestamp";
+    /**
+     * Column name for the column storing the {@link Event.EventType#getDatabaseIdentifier()}.
+     */
+    public static final String COLUMN_TYPE = "type";
+    /**
+     * Column name for the column storing the foreign key referencing the {@link Measurement} for this
+     * {@link Event} if the {@code Event} is linked to a {@code Measurement}.
+     */
+    public static final String COLUMN_MEASUREMENT_FK = "measurement_fk";
+    /**
+     * An array containing all the column names used by a {@link EventTable}.
+     */
+    private static final String[] COLUMNS = {BaseColumns._ID, COLUMN_TIMESTAMP, COLUMN_TYPE, COLUMN_MEASUREMENT_FK};
+
+    /**
+     * Provides a completely initialized object as a representation of a table containing {@link Event}s in the
+     * database.
+     */
+    protected EventTable() {
+        super(URI_PATH);
+    }
+
+    @Override
+    protected String getCreateStatement() {
+        // The COLUMN_MEASUREMENT_FK may be null if the Event is not linked to a Measurement.
+        return "CREATE TABLE " + getName() + " (" + BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
+                + COLUMN_TIMESTAMP + " INTEGER NOT NULL, " + COLUMN_TYPE + " TEXT NOT NULL, " + COLUMN_MEASUREMENT_FK
+                + " INTEGER);";
+    }
+
+    /**
+     * Don't forget to update the {@link DatabaseHelper}'s {@code DATABASE_VERSION} if you upgrade this table.
+     *
+     * Remaining documentation: {@link AbstractCyfaceMeasurementTable#onUpgrade}
+     */
+    @Override
+    public void onUpgrade(final SQLiteDatabase database, final int oldVersion, final int newVersion) {
+
+        // noinspection SwitchStatementWithTooFewBranches - because others will follow and it's an easier read
+        switch (oldVersion) {
+            case 11:
+                onCreate(database);
+                // continues with the next incremental upgrade until return ! -->
+        }
+
+    }
+
+    @Override
+    protected String[] getDatabaseTableColumns() {
+        return COLUMNS;
+    }
+}

--- a/persistence/src/main/java/de/cyface/persistence/GeoLocationsTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/GeoLocationsTable.java
@@ -12,7 +12,7 @@ import de.cyface.persistence.model.Measurement;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.3.0
+ * @version 2.3.1
  * @since 1.0.0
  */
 public class GeoLocationsTable extends AbstractCyfaceMeasurementTable {

--- a/persistence/src/main/java/de/cyface/persistence/GeoLocationsTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/GeoLocationsTable.java
@@ -46,12 +46,11 @@ public class GeoLocationsTable extends AbstractCyfaceMeasurementTable {
      * {@link GeoLocation}.
      */
     public static final String COLUMN_MEASUREMENT_FK = "measurement_fk";
-
     /**
      * An array containing all the column names used by a geo location table.
      */
-    private static final String[] COLUMNS = {BaseColumns._ID, COLUMN_GEOLOCATION_TIME, COLUMN_LAT, COLUMN_LON, COLUMN_SPEED,
-            COLUMN_ACCURACY, COLUMN_MEASUREMENT_FK};
+    private static final String[] COLUMNS = {BaseColumns._ID, COLUMN_GEOLOCATION_TIME, COLUMN_LAT, COLUMN_LON,
+            COLUMN_SPEED, COLUMN_ACCURACY, COLUMN_MEASUREMENT_FK};
 
     /**
      * Provides a completely initialized object as a representation of a table containing geo locations in the database.
@@ -82,7 +81,7 @@ public class GeoLocationsTable extends AbstractCyfaceMeasurementTable {
                 // This upgrade from 8 to 10 is executed for all SDK versions below 3 (which is v 10).
                 // We don't support an soft-upgrade there but reset the database
 
-                // We use a transaction as this lead to an unresolvable error where the IdentifierTable
+                // We don't use a transaction as this lead to an unresolvable error where the IdentifierTable
                 // was not created in time for the first database query.
 
                 database.execSQL("DELETE FROM gps_points;");

--- a/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
@@ -2,6 +2,7 @@ package de.cyface.persistence;
 
 import android.database.sqlite.SQLiteDatabase;
 import android.provider.BaseColumns;
+
 import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
@@ -14,7 +15,7 @@ import de.cyface.persistence.serialization.MeasurementSerializer;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.4.1
+ * @version 2.4.2
  * @since 1.0.0
  */
 public class MeasurementTable extends AbstractCyfaceMeasurementTable {

--- a/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
@@ -89,7 +89,7 @@ public class MeasurementTable extends AbstractCyfaceMeasurementTable {
                 // This upgrade from 8 to 10 is executed for all SDK versions below 3 (which is v 10).
                 // We don't support an soft-upgrade there but reset the database
 
-                // We use a transaction as this lead to an unresolvable error where the IdentifierTable
+                // We don't use a transaction as this lead to an unresolvable error where the IdentifierTable
                 // was not created in time for the first database query.
 
                 database.execSQL("DELETE FROM measurement;");

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -47,7 +47,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 11.0.1
+ * @version 12.0.0
  * @since 2.0.0
  */
 public class PersistenceLayer<B extends PersistenceBehaviour> {
@@ -842,7 +842,8 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      */
     public void logEvent(@NonNull final Event.EventType eventType, @NonNull final Measurement measurement) {
         final long timestamp = System.currentTimeMillis();
-        Log.v(TAG, "Storing Event:" + eventType + " for Measurement " + measurement.getIdentifier() + " at " + timestamp);
+        Log.v(TAG,
+                "Storing Event:" + eventType + " for Measurement " + measurement.getIdentifier() + " at " + timestamp);
 
         final ContentValues contentValues = new ContentValues();
         contentValues.put(EventTable.COLUMN_TYPE, eventType.getDatabaseIdentifier());

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -845,6 +845,6 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
         contentValues.put(EventTable.COLUMN_TIMESTAMP, System.currentTimeMillis());
         contentValues.put(EventTable.COLUMN_MEASUREMENT_FK, measurement.getIdentifier());
 
-        resolver.insert(getMeasurementUri(), contentValues);
+        resolver.insert(getEventUri(), contentValues);
     }
 }

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -28,11 +28,13 @@ import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import de.cyface.persistence.model.Event;
 import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.PointMetaData;
+import de.cyface.persistence.model.Track;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.persistence.serialization.MeasurementSerializer;
 import de.cyface.persistence.serialization.Point3dFile;
@@ -490,53 +492,123 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
     }
 
     /**
-     * Loads the track of {@link GeoLocation} objects for the provided {@link Measurement}.
-     * TODO [STAD-6]: Slice the tracks into sub tracks when the measurement was paused and resumed.
-     * Right now the full unsliced track is always the only sub track that is returned.
+     * Loads the {@link Track}s for the provided {@link Measurement}.
      * <p>
-     * This method loads the complete track into memory. For large tracks this could slow down the device or even reach
-     * the applications memory limit.
+     * This method loads the complete {@code Track}s into memory. For large {@code Track}s this could slow down the
+     * device or even reach the applications memory limit.
+     *
+     * TODO [MOV-554]: provide a custom list implementation that loads only small portions into memory.
      *
      * TODO [CY-4438]: From the current implementations (MeasurementContentProviderClient loader and resolver.query) is
      * the loader the faster solution. However, we should upgrade the database access as Android changed it's API.
      *
-     * TODO [MOV-554]: provide a custom list implementation that loads only small portions into memory.
-     *
      * @param measurementIdentifier The id of the {@code Measurement} to load the track for.
-     * @return The sub tracks associated with the {@code Measurement}. Right now we return the full track as
-     *         the first sub track which contains list of ordered (by timestamp) {@code GeoLocation}s.
-     *         If no {@code GeoLocation}s exists, an empty list is returned.
+     * @return The {@link Track}s associated with the {@code Measurement}. If no {@code GeoLocation}s exists, an empty
+     *         list is returned.
+     * @throws CursorIsNullException when accessing the {@code ContentProvider} failed
      */
     @SuppressWarnings("unused") // Sdk implementing apps (RS) use this api to display the tracks
-    public List<List<GeoLocation>> loadTrack(final long measurementIdentifier) {
+    public List<Track> loadTracks(final long measurementIdentifier) throws CursorIsNullException {
 
-        final List<List<GeoLocation>> subTracks = new ArrayList<>();
-        Cursor cursor = null;
+        Cursor geoLocationCursor = null;
+        Cursor eventCursor = null;
         try {
-            cursor = resolver.query(getGeoLocationsUri(), null, GeoLocationsTable.COLUMN_MEASUREMENT_FK + "=?",
+            // Load GeoLocations
+            geoLocationCursor = resolver.query(getGeoLocationsUri(), null,
+                    GeoLocationsTable.COLUMN_MEASUREMENT_FK + "=?",
                     new String[] {Long.valueOf(measurementIdentifier).toString()},
                     GeoLocationsTable.COLUMN_GEOLOCATION_TIME + " ASC");
-            if (cursor == null) {
+            Validate.softCatchNullCursor(geoLocationCursor);
+            if (geoLocationCursor.getCount() == 0) {
                 return Collections.emptyList();
             }
 
-            final List<GeoLocation> fullTrack = new ArrayList<>(cursor.getCount());
-            while (cursor.moveToNext()) {
-                final double lat = cursor.getDouble(cursor.getColumnIndex(GeoLocationsTable.COLUMN_LAT));
-                final double lon = cursor.getDouble(cursor.getColumnIndex(GeoLocationsTable.COLUMN_LON));
-                final long timestamp = cursor.getLong(cursor.getColumnIndex(GeoLocationsTable.COLUMN_GEOLOCATION_TIME));
-                final double speed = cursor.getDouble(cursor.getColumnIndex(GeoLocationsTable.COLUMN_SPEED));
-                final float accuracy = cursor.getFloat(cursor.getColumnIndex(GeoLocationsTable.COLUMN_ACCURACY));
-                fullTrack.add(new GeoLocation(lat, lon, timestamp, speed, accuracy));
-            }
+            // Load Events to slice measurements on pause events
+            eventCursor = resolver.query(getEventUri(), null, GeoLocationsTable.COLUMN_MEASUREMENT_FK + "=?",
+                    new String[] {Long.valueOf(measurementIdentifier).toString()},
+                    EventTable.COLUMN_TIMESTAMP + " ASC");
+            Validate.softCatchNullCursor(eventCursor);
 
-            subTracks.add(fullTrack);
-            return subTracks;
+            return loadTracks(geoLocationCursor, eventCursor);
         } finally {
-            if (cursor != null) {
-                cursor.close();
+            if (geoLocationCursor != null) {
+                geoLocationCursor.close();
+            }
+            if (eventCursor != null) {
+                eventCursor.close();
             }
         }
+    }
+
+    /**
+     * Loads the {@link Track}s for the provided {@link GeoLocation} cursor sliced using the provided {@link Event}
+     * cursor.
+     *
+     * @param geoLocationCursor The {@code GeoLocation} cursor which points to the locations to be loaded.
+     * @param eventCursor The {@code Event} cursor which points to the events annotation the corresponding
+     *            {@link Measurement}.
+     * @return The {@link Track}s for the corresponding {@code Measurement} loaded.
+     */
+    @NonNull
+    private List<Track> loadTracks(@NonNull final Cursor geoLocationCursor, @NonNull final Cursor eventCursor) {
+        final List<Track> tracks = new ArrayList<>();
+
+        // Slice Tracks before resume events
+        // This helps to allocate GeoLocations which are captured just after pause was hit to the track which just
+        // ended.
+        while (eventCursor.moveToNext()) {
+            final Event.EventType eventType = Event.EventType
+                    .valueOf(eventCursor.getString(eventCursor.getColumnIndex(EventTable.COLUMN_TYPE)));
+            if (eventType != Event.EventType.LIFECYCLE_RESUME) {
+                continue;
+            }
+
+            // get all geolocations captured before this RESUME event
+            final long eventTime = eventCursor.getLong(eventCursor.getColumnIndex(EventTable.COLUMN_TIMESTAMP));
+            final Track track = new Track();
+            while (geoLocationCursor.moveToNext()) {
+                final GeoLocation location = loadGeoLocation(geoLocationCursor);
+                if (location.getTimestamp() >= eventTime) {
+                    break; // Next track reached
+                }
+                track.add(location);
+            }
+            if (track.getGeoLocations().size() > 0) {
+                tracks.add(track);
+            }
+        }
+
+        // Create track for tail (remaining locations after the last pause event)
+        // This is ether the track between start[, pause] and stop or resume[, pause] and stop.
+        final Track track = new Track();
+        while (geoLocationCursor.moveToNext()) {
+            final GeoLocation location = loadGeoLocation(geoLocationCursor);
+            track.add(location);
+        }
+        if (track.getGeoLocations().size() > 0) {
+            tracks.add(track);
+        }
+
+        return tracks;
+    }
+
+    /**
+     * Loads the {@link GeoLocation} at the {@code Cursor}'s current position.
+     *
+     * @param geoLocationCursor the {@code Cursor} pointing to a {@code GeoLocation} in the database.
+     * @return the {@code GeoLocation} loaded.
+     */
+    private GeoLocation loadGeoLocation(@NonNull final Cursor geoLocationCursor) {
+
+        final double lat = geoLocationCursor.getDouble(geoLocationCursor.getColumnIndex(GeoLocationsTable.COLUMN_LAT));
+        final double lon = geoLocationCursor.getDouble(geoLocationCursor.getColumnIndex(GeoLocationsTable.COLUMN_LON));
+        final long timestamp = geoLocationCursor
+                .getLong(geoLocationCursor.getColumnIndex(GeoLocationsTable.COLUMN_GEOLOCATION_TIME));
+        final double speed = geoLocationCursor
+                .getDouble(geoLocationCursor.getColumnIndex(GeoLocationsTable.COLUMN_SPEED));
+        final float accuracy = geoLocationCursor
+                .getFloat(geoLocationCursor.getColumnIndex(GeoLocationsTable.COLUMN_ACCURACY));
+        return new GeoLocation(lat, lon, timestamp, speed, accuracy);
     }
 
     /**
@@ -565,6 +637,15 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      */
     public Uri getGeoLocationsUri() {
         return Utils.getGeoLocationsUri(authority);
+    }
+
+    /**
+     * @return The content provider {@link Uri} for the {@link EventTable}.
+     *         <p>
+     *         <b>ATTENTION:</b> This method should not be needed from outside the SDK.
+     */
+    public Uri getEventUri() {
+        return Utils.getEventUri(authority);
     }
 
     /**
@@ -748,5 +829,22 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      */
     public B getPersistenceBehaviour() {
         return persistenceBehaviour;
+    }
+
+    /**
+     * Stores a new {@link Event} in the {@link PersistenceLayer} which is linked to a {@link Measurement}.
+     *
+     * @param eventType The {@link Event.EventType} to be logged.
+     * @param measurement The {@code Measurement} which is linked to the {@code Event}.
+     */
+    public void logEvent(@NonNull final Event.EventType eventType, @NonNull final Measurement measurement) {
+        Log.v(TAG, "Storing Event:" + eventType + " for Measurement " + measurement.getIdentifier());
+
+        final ContentValues contentValues = new ContentValues();
+        contentValues.put(EventTable.COLUMN_TYPE, eventType.getDatabaseIdentifier());
+        contentValues.put(EventTable.COLUMN_TIMESTAMP, System.currentTimeMillis());
+        contentValues.put(EventTable.COLUMN_MEASUREMENT_FK, measurement.getIdentifier());
+
+        resolver.insert(getMeasurementUri(), contentValues);
     }
 }

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -452,8 +452,10 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
 
         deletePoint3dData(measurementIdentifier);
 
-        // Delete {@link GeoLocation}s and {@link Measurement} entry from database
+        // Delete {@link GeoLocation}s, {@link Event}s and {@link Measurement} entry from database
         resolver.delete(getGeoLocationsUri(), GeoLocationsTable.COLUMN_MEASUREMENT_FK + "=?",
+                new String[] {Long.valueOf(measurementIdentifier).toString()});
+        resolver.delete(getEventUri(), EventTable.COLUMN_MEASUREMENT_FK + "=?",
                 new String[] {Long.valueOf(measurementIdentifier).toString()});
         resolver.delete(getMeasurementUri(), _ID + "=?", new String[] {Long.valueOf(measurementIdentifier).toString()});
     }

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -571,6 +571,7 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
             while (geoLocationCursor.moveToNext()) {
                 final GeoLocation location = loadGeoLocation(geoLocationCursor);
                 if (location.getTimestamp() >= eventTime) {
+                    geoLocationCursor.moveToPrevious();
                     break; // Next track reached
                 }
                 track.add(location);
@@ -840,11 +841,12 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      * @param measurement The {@code Measurement} which is linked to the {@code Event}.
      */
     public void logEvent(@NonNull final Event.EventType eventType, @NonNull final Measurement measurement) {
-        Log.v(TAG, "Storing Event:" + eventType + " for Measurement " + measurement.getIdentifier());
+        final long timestamp = System.currentTimeMillis();
+        Log.v(TAG, "Storing Event:" + eventType + " for Measurement " + measurement.getIdentifier() + " at " + timestamp);
 
         final ContentValues contentValues = new ContentValues();
         contentValues.put(EventTable.COLUMN_TYPE, eventType.getDatabaseIdentifier());
-        contentValues.put(EventTable.COLUMN_TIMESTAMP, System.currentTimeMillis());
+        contentValues.put(EventTable.COLUMN_TIMESTAMP, timestamp);
         contentValues.put(EventTable.COLUMN_MEASUREMENT_FK, measurement.getIdentifier());
 
         resolver.insert(getEventUri(), contentValues);

--- a/persistence/src/main/java/de/cyface/persistence/Utils.java
+++ b/persistence/src/main/java/de/cyface/persistence/Utils.java
@@ -1,13 +1,14 @@
 package de.cyface.persistence;
 
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
 
 /**
  * This utility class contains shared static methods used by multiple modules.
  *
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 1.1.0
  * @since 3.0.0
  */
 public class Utils {
@@ -40,5 +41,15 @@ public class Utils {
      */
     public static Uri getIdentifierUri(@NonNull final String authority) {
         return new Uri.Builder().scheme("content").authority(authority).appendPath(IdentifierTable.URI_PATH).build();
+    }
+
+    /**
+     * (!) It's important to provide the authority string as parameter because depending on from where you call this
+     * you want to access your own authorities database.
+     *
+     * @param authority The authority to access the database
+     */
+    public static Uri getEventUri(@NonNull final String authority) {
+        return new Uri.Builder().scheme("content").authority(authority).appendPath(EventTable.URI_PATH).build();
     }
 }

--- a/persistence/src/main/java/de/cyface/persistence/model/Event.java
+++ b/persistence/src/main/java/de/cyface/persistence/model/Event.java
@@ -1,0 +1,84 @@
+package de.cyface.persistence.model;
+
+import java.util.Arrays;
+
+import androidx.annotation.NonNull;
+
+/**
+ * {@code Event}s are things that happen on the user device which may be important and are, thus, logged.
+ * For examples see the {@link EventType}s.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.0
+ */
+public class Event {
+
+    /**
+     * The {@code EventType} collected by this {@link Event}.
+     */
+    private EventType type;
+    /**
+     * The timestamp at which this {@code Event} was captured in milliseconds since 1.1.1970.
+     */
+    private long timestamp;
+
+    /**
+     * @param type The {@link EventType} collected by this {@link Event}.
+     * @param timestamp The timestamp at which this {@code Event} was captured in milliseconds since 1.1.1970.
+     */
+    public Event(EventType type, long timestamp) {
+        this.type = type;
+        this.timestamp = timestamp;
+    }
+
+    public EventType getType() {
+        return type;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Event event = (Event)o;
+        return timestamp == event.timestamp && type == event.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(new Object[] {type, timestamp});
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "Event{" + "type=" + type + ", timestamp=" + timestamp + '}';
+    }
+
+    /**
+     * Defines the {@code EventType}s which may be collected.
+     * <p>
+     * An example are the use of the life-cycle methods such as start, pause, resume, etc. which are required to
+     * slice {@link Measurement}s into {@link Track}s before they are resumed.
+     */
+    public enum EventType {
+        LIFECYCLE_START("LIFECYCLE_START"), LIFECYCLE_PAUSE("LIFECYCLE_PAUSE"), LIFECYCLE_RESUME(
+                "LIFECYCLE_RESUME"), LIFECYCLE_STOP("LIFECYCLE_STOP");
+
+        private String databaseIdentifier;
+
+        EventType(final String databaseIdentifier) {
+            this.databaseIdentifier = databaseIdentifier;
+        }
+
+        public String getDatabaseIdentifier() {
+            return databaseIdentifier;
+        }
+    }
+}

--- a/persistence/src/main/java/de/cyface/persistence/model/Track.java
+++ b/persistence/src/main/java/de/cyface/persistence/model/Track.java
@@ -1,0 +1,68 @@
+package de.cyface.persistence.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+
+/**
+ * A {@code Track} consists of {@link GeoLocation}s collected for a {@link Measurement}. Its {@code GeoLocation}s are
+ * ordered by time.
+ * <p>
+ * A {@code Track} begins with the first {@code GeoLocation} collected after start or resume was triggered
+ * and stops with the last collected {@code GeoLocation} before the next resume command is triggered or when the very
+ * last locations is reached.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.0
+ */
+public class Track {
+
+    /**
+     * The {@link GeoLocation}s collected for this {@code Track}.
+     */
+    private List<GeoLocation> geoLocations;
+
+    /**
+     * @param geoLocations The {@link GeoLocation}s collected for this {@link Track}.
+     */
+    public Track(@NonNull final List<GeoLocation> geoLocations) {
+        this.geoLocations = geoLocations;
+    }
+
+    public Track() {
+    }
+
+    /**
+     * @param location The {@link GeoLocation} to be added at the end of the {@link Track}.
+     */
+    public void add(@NonNull final GeoLocation location) {
+        geoLocations.add(location);
+    }
+
+    public List<GeoLocation> getGeoLocations() {
+        return geoLocations;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "Track{" + "geoLocations=" + geoLocations + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Track track = (Track)o;
+        return geoLocations.equals(track.geoLocations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(geoLocations.toArray());
+    }
+}

--- a/persistence/src/main/java/de/cyface/persistence/model/Track.java
+++ b/persistence/src/main/java/de/cyface/persistence/model/Track.java
@@ -1,5 +1,6 @@
 package de.cyface.persistence.model;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class Track {
     }
 
     public Track() {
+        this.geoLocations = new ArrayList<>();
     }
 
     /**

--- a/persistence/src/main/java/de/cyface/persistence/model/Track.java
+++ b/persistence/src/main/java/de/cyface/persistence/model/Track.java
@@ -25,13 +25,6 @@ public class Track {
      */
     private List<GeoLocation> geoLocations;
 
-    /**
-     * @param geoLocations The {@link GeoLocation}s collected for this {@link Track}.
-     */
-    public Track(@NonNull final List<GeoLocation> geoLocations) {
-        this.geoLocations = geoLocations;
-    }
-
     public Track() {
         this.geoLocations = new ArrayList<>();
     }

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -120,7 +120,7 @@ public final class SyncAdapterTest {
         // GeoLocation
         final Measurement loadedMeasurement = persistence.loadMeasurement(measurementIdentifier);
         assertThat(loadedMeasurement, notNullValue());
-        final List<List<GeoLocation>> subTracks = persistence.loadTrack(loadedMeasurement.getIdentifier());
+        final List<List<GeoLocation>> subTracks = persistence.loadTracks(loadedMeasurement.getIdentifier());
         assertThat(subTracks.get(0).size(), is(1));
     }
 
@@ -178,7 +178,7 @@ public final class SyncAdapterTest {
         // GeoLocation
         final Measurement loadedMeasurement = persistence.loadMeasurement(measurementIdentifier);
         assertThat(loadedMeasurement, notNullValue());
-        final List<List<GeoLocation>> subTracks = persistence.loadTrack(loadedMeasurement.getIdentifier());
+        final List<List<GeoLocation>> subTracks = persistence.loadTracks(loadedMeasurement.getIdentifier());
         assertThat(subTracks.get(0).size(), is(locationCount));
     }
 

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +42,7 @@ import de.cyface.persistence.PersistenceLayer;
 import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
+import de.cyface.persistence.model.Track;
 import de.cyface.utils.CursorIsNullException;
 import de.cyface.utils.Validate;
 
@@ -120,8 +122,8 @@ public final class SyncAdapterTest {
         // GeoLocation
         final Measurement loadedMeasurement = persistence.loadMeasurement(measurementIdentifier);
         assertThat(loadedMeasurement, notNullValue());
-        final List<List<GeoLocation>> subTracks = persistence.loadTracks(loadedMeasurement.getIdentifier());
-        assertThat(subTracks.get(0).size(), is(1));
+        final List<Track> tracks = persistence.loadTracks(loadedMeasurement.getIdentifier());
+        assertThat(tracks.get(0).getGeoLocations().size(), is(1));
     }
 
     /**
@@ -178,8 +180,8 @@ public final class SyncAdapterTest {
         // GeoLocation
         final Measurement loadedMeasurement = persistence.loadMeasurement(measurementIdentifier);
         assertThat(loadedMeasurement, notNullValue());
-        final List<List<GeoLocation>> subTracks = persistence.loadTracks(loadedMeasurement.getIdentifier());
-        assertThat(subTracks.get(0).size(), is(locationCount));
+        final List<Track> tracks = persistence.loadTracks(loadedMeasurement.getIdentifier());
+        assertThat(tracks.get(0).getGeoLocations().size(), is(locationCount));
     }
 
     /**

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/DataTransmissionTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/DataTransmissionTest.java
@@ -111,7 +111,7 @@ public class DataTransmissionTest {
         final Point3dFile rotationsFile = new Point3dFile(context, measurementIdentifier,
                 Point3dFile.ROTATIONS_FOLDER_NAME, Point3dFile.ROTATION_FILE_EXTENSION);
         final Point3dFile directionsFile = new Point3dFile(context, measurementIdentifier,
-                Point3dFile.DIRECTIONS_FOLDER_NAME, Point3dFile.ROTATION_FILE_EXTENSION);
+                Point3dFile.DIRECTIONS_FOLDER_NAME, Point3dFile.DIRECTION_FILE_EXTENSION);
         insertPoint3d(accelerationsFile, 1501662635973L, 10.1189575, -0.15088624, 0.2921924);
         insertPoint3d(accelerationsFile, 1501662635981L, 10.116563, -0.16765137, 0.3544629);
         insertPoint3d(accelerationsFile, 1501662635983L, 10.171648, -0.2921924, 0.3784131);

--- a/synchronization/src/main/java/de/cyface/synchronization/DataTransmissionException.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/DataTransmissionException.java
@@ -5,7 +5,8 @@ package de.cyface.synchronization;
  * all the details available and relevant to diagnose the error case.
  *
  * @author Klemens Muthmann
- * @version 1.0.1
+ * @author Armin Schnabel
+ * @version 2.0.0
  * @since 1.0.0
  */
 public final class DataTransmissionException extends Exception {
@@ -23,7 +24,7 @@ public final class DataTransmissionException extends Exception {
      * @param errorName The error name as a short form for the detailed error message.
      * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
      */
-    public DataTransmissionException(final int httpStatusCode, final String errorName, final String detailedMessage) {
+    DataTransmissionException(final int httpStatusCode, final String errorName, final String detailedMessage) {
         this(httpStatusCode, errorName, detailedMessage, null);
 
     }
@@ -34,7 +35,7 @@ public final class DataTransmissionException extends Exception {
      * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
      * @param cause The <code>Exception</code> that caused this one.
      */
-    public DataTransmissionException(final int httpStatusCode, final String errorName, final String detailedMessage,
+    private DataTransmissionException(final int httpStatusCode, final String errorName, final String detailedMessage,
             final Exception cause) {
         super(detailedMessage, cause);
         this.httpStatusCode = httpStatusCode;
@@ -44,6 +45,7 @@ public final class DataTransmissionException extends Exception {
     /**
      * @return The HTTP status error code causing this <code>Exception</code>.
      */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // Makes sense to offer those getters
     public int getHttpStatusCode() {
         return httpStatusCode;
     }
@@ -51,6 +53,7 @@ public final class DataTransmissionException extends Exception {
     /**
      * @return The error name as a short form for the detailed error message.
      */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // Makes sense to offer those getters
     public String getErrorName() {
         return errorName;
     }

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -42,7 +42,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.4.2
+ * @version 2.4.3
  * @since 2.0.0
  */
 public final class SyncAdapter extends AbstractThreadedSyncAdapter {

--- a/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
+++ b/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
@@ -282,7 +282,7 @@ public class SharedTestUtils {
         assertThat(persistence.loadMeasurementStatus(measurementIdentifier), is(equalTo(status)));
 
         // Check the GeoLocations
-        final List<List<GeoLocation>> loadedSubTracks = persistence.loadTrack(measurementIdentifier);
+        final List<List<GeoLocation>> loadedSubTracks = persistence.loadTracks(measurementIdentifier);
         assertThat(loadedSubTracks.get(0).size(), is(locationCount));
 
         // We can only check the PointMetaData for measurements which are not open anymore (else it's still in cache)

--- a/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
+++ b/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
@@ -29,9 +29,9 @@ import de.cyface.persistence.DefaultFileAccess;
 import de.cyface.persistence.DefaultPersistenceBehaviour;
 import de.cyface.persistence.FileAccessLayer;
 import de.cyface.persistence.GeoLocationsTable;
-import de.cyface.persistence.IdentifierTable;
 import de.cyface.persistence.NoSuchMeasurementException;
 import de.cyface.persistence.PersistenceLayer;
+import de.cyface.persistence.model.Event;
 import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
@@ -49,7 +49,7 @@ import de.cyface.utils.Validate;
  * It's located in the main folder to be compiled and imported as dependency in the testImplementations.
  *
  * @author Armin Schnabel
- * @version 4.0.2
+ * @version 4.0.3
  * @since 3.0.0
  */
 public class SharedTestUtils {
@@ -146,7 +146,7 @@ public class SharedTestUtils {
      * @param context The {@link Context} required to access the file persistence layer
      * @param resolver The {@link ContentResolver} required to access the database
      * @return number of rows removed from the database and number of <b>FILES</b> (not points) deleted. The earlier
-     *         includes {@link Measurement}s and {@link GeoLocation}s and the {@link IdentifierTable} (i.e. device id).
+     *         includes {@link Measurement}s, {@link GeoLocation}s and {@link Event}s.
      *         The later includes the {@link Point3dFile}s.
      */
     public static int clearPersistenceLayer(@NonNull final Context context, @NonNull final ContentResolver resolver,
@@ -198,7 +198,7 @@ public class SharedTestUtils {
         // However this should be okay to ignore for now as the identifier table should never be reset unless the
         // database itself is removed when the app is uninstalled or the app data is deleted.
         // final int removedIdentifierRows = resolver.delete(getIdentifierUri(authority), null, null);
-        return removedFiles + /* removedIdentifierRows + */ removedGeoLocations + removedMeasurements;
+        return removedFiles + /* removedIdentifierRows + */ removedGeoLocations + removedEvents + removedMeasurements;
     }
 
     /**

--- a/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
+++ b/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
@@ -1,6 +1,7 @@
 package de.cyface.testutils;
 
 import static de.cyface.persistence.Constants.TAG;
+import static de.cyface.persistence.Utils.getEventUri;
 import static de.cyface.persistence.Utils.getGeoLocationsUri;
 import static de.cyface.persistence.Utils.getMeasurementUri;
 import static de.cyface.persistence.model.MeasurementStatus.FINISHED;
@@ -191,6 +192,7 @@ public class SharedTestUtils {
 
         // Remove database entries
         final int removedGeoLocations = resolver.delete(getGeoLocationsUri(authority), null, null);
+        final int removedEvents = resolver.delete(getEventUri(authority), null, null);
         final int removedMeasurements = resolver.delete(getMeasurementUri(authority), null, null);
         // Unclear why this breaks the life-cycle tests in DataCapturingServiceTest.
         // However this should be okay to ignore for now as the identifier table should never be reset unless the

--- a/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
+++ b/testutils/src/main/java/de/cyface/testutils/SharedTestUtils.java
@@ -36,6 +36,7 @@ import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Point3d;
 import de.cyface.persistence.model.PointMetaData;
+import de.cyface.persistence.model.Track;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.persistence.serialization.MeasurementSerializer;
 import de.cyface.persistence.serialization.Point3dFile;
@@ -281,9 +282,9 @@ public class SharedTestUtils {
         assertThat(loadedMeasurement, notNullValue());
         assertThat(persistence.loadMeasurementStatus(measurementIdentifier), is(equalTo(status)));
 
-        // Check the GeoLocations
-        final List<List<GeoLocation>> loadedSubTracks = persistence.loadTracks(measurementIdentifier);
-        assertThat(loadedSubTracks.get(0).size(), is(locationCount));
+        // Check the Tracks
+        final List<Track> loadedTracks = persistence.loadTracks(measurementIdentifier);
+        assertThat(loadedTracks.get(0).getGeoLocations().size(), is(locationCount));
 
         // We can only check the PointMetaData for measurements which are not open anymore (else it's still in cache)
         if (status != OPEN) {


### PR DESCRIPTION
 _Der PR beinhaltet nun auch eine aufgeräumte und homogen zu den Migration Guides strukturierte README (ca. 40% der Line-Changes), siehe MOV-594._

**Hier sind die Tests:**
CapturedDataWriterTest
- testDeleteMeasurement prüft, dass die Events beim Löschen der Messungen über das UI ebenfalls gelöscht werden.
- testLoadTrack_startPauseResumeStop prüft, dass loadTrack() nach einer Messung nach dem Schema start, pause, resume, stop korrekt in Sub Tracks geteilt und zurückgegeben werden. Da das ein Integration Test ist, wird implizit mit geprüft, dass das Speichern und Laden der Events stattfindet.
- testLoadTrack_startPauseResumePauseStop prüft das gleiche für diesen flow
- testLoadTrack_startPauseStop prüft das gleiche für diesen flow
- testLoadTrack_startStop prüft das gleiche für diesen flow

DataCapturingServiceTest
- testStartPauseResumeStop prüft, dass beim Aufrufen der Life-Cycle Methoden (start, pause, resume, stop) auch die Events korrekt in dieser Reihenfolge angelegt werden.

**Am besten kurz bestätigen, dass du das hier gelesen hast, nicht dass dir die Info dann beim Updatemeeting fehlt.**