### PR TITLE
Bug/mov 609 sync without wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,7 @@ public class MainFragment extends Fragment implements ConnectionStatusListener {
             return;
         }
         
-        // Login and create account 
-        // a) Static token variant:
-        dataCapturingService.registerJWTAuthToken(username, token);
-        // or b) Login via LoginActivity and using dynamic tokens
+        // Login via LoginActivity, create account and using dynamic tokens
         // The LoginActivity is called by Android which handles the account creation
         accountManager.addAccount(ACCOUNT_TYPE, AUTH_TOKEN_TYPE, null, null,
             getMainActivityFromContext(context), new AccountManagerCallback<Bundle>() {

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -33,7 +33,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 9.0.0
+ * @version 9.0.1
  * @since 2.0.0
  */
 public final class CyfaceDataCapturingService extends DataCapturingService {

--- a/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
+++ b/datacapturing/src/cyface/java/de/cyface/datacapturing/CyfaceDataCapturingService.java
@@ -105,6 +105,7 @@ public final class CyfaceDataCapturingService extends DataCapturingService {
      */
     @SuppressWarnings("unused") // This is called by the SDK implementing app in its onDestroyView
     public void shutdownDataCapturingService() throws SynchronisationException {
+
         getWiFiSurveyor().stopSurveillance();
         shutdownConnectionStatusReceiver();
     }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -485,7 +485,7 @@ public abstract class DataCapturingService {
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // Used by implementing app (CY)
     public void scheduleSyncNow() {
-        getWiFiSurveyor().scheduleSyncNow();
+        surveyor.scheduleSyncNow();
     }
 
     /**
@@ -867,11 +867,11 @@ public abstract class DataCapturingService {
     }
 
     /**
-     * see {@link WiFiSurveyor#isConnected()}
+     * see {@link WiFiSurveyor#isConnectedToSyncableNetwork()}
      */
     @SuppressWarnings("unused") // Allows implementing apps (CY) to only trigger sync manually when connected
     public boolean isConnected() {
-        return getWiFiSurveyor().isConnected();
+        return surveyor.isConnectedToSyncableNetwork();
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -92,7 +92,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 14.0.3
+ * @version 14.0.4
  * @since 1.0.0
  */
 public abstract class DataCapturingService {

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -53,7 +53,7 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 8.0.0
+ * @version 8.0.1
  * @since 2.0.0
  */
 @SuppressWarnings({"unused", "WeakerAccess"}) // Sdk implementing apps (SR) use to create a DataCapturingService

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -225,6 +225,9 @@ public class MovebisDataCapturingService extends DataCapturingService {
             throws SynchronisationException {
         final AccountManager accountManager = AccountManager.get(getContext());
 
+        // The workflow here is slightly different from the one in CyfaceDataCapturingService.
+        // If problems are reported, ensure they are exactly the same (i.e. reuse existing account).
+
         // Create a "dummy" account used for auto synchronization. Null password as the token is static
         final Account synchronizationAccount = getWiFiSurveyor().createAccount(username, null);
 

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -52,7 +52,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.2.3
+ * @version 2.2.4
  * @since 2.4.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -52,7 +52,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.2.4
+ * @version 2.2.6
  * @since 2.4.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -156,13 +156,15 @@ public final class SyncAdapterTest {
     @Test
     @LargeTest // ~ 8-10 minutes
     public void testOnPerformSyncWithLargeMeasurement() throws NoSuchMeasurementException, CursorIsNullException {
-
-        // Arrange
-        // Insert data to be synced - 3_000_000 is the minimum which reproduced MOV-515 on N5X emulator
-        final PersistenceLayer<DefaultPersistenceBehaviour> persistence = new PersistenceLayer<>(context,
-                contentResolver, AUTHORITY, new DefaultPersistenceBehaviour());
+        // 3_000_000 is the minimum which reproduced MOV-515 on N5X emulator
         final int point3dCount = 3_000_000;
         final int locationCount = 3_000;
+
+        // Arrange
+        // Insert data to be synced
+        final PersistenceLayer<DefaultPersistenceBehaviour> persistence = new PersistenceLayer<>(context,
+                contentResolver, AUTHORITY, new DefaultPersistenceBehaviour());
+        persistence.restoreOrCreateDeviceId(); // is usually called by the DataCapturingService
         final Measurement insertedMeasurement = insertSampleMeasurementWithData(context, AUTHORITY,
                 MeasurementStatus.FINISHED, persistence, point3dCount, locationCount);
         final long measurementIdentifier = insertedMeasurement.getIdentifier();
@@ -180,7 +182,7 @@ public final class SyncAdapterTest {
 
             final Bundle testBundle = new Bundle();
             testBundle.putString(MOCKED_IS_PERIODIC_SYNC_DISABLED_FALSE, "");
-            oocut.onPerformSync(account, new Bundle(), AUTHORITY, client, result);
+            oocut.onPerformSync(account, testBundle, AUTHORITY, client, result);
         } finally {
             if (client != null) {
                 client.close();

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -58,7 +58,7 @@ public final class SyncAdapterTest {
         Account newAccount = new Account(TestUtils.DEFAULT_USERNAME, ACCOUNT_TYPE);
         if (am.addAccountExplicitly(newAccount, TestUtils.DEFAULT_PASSWORD, Bundle.EMPTY)) {
             ContentResolver.setIsSyncable(newAccount, AUTHORITY, 1);
-            ContentResolver.setSyncAutomatically(newAccount, AUTHORITY, true);
+            ContentResolver.addPeriodicSync(newAccount, AUTHORITY, Bundle.EMPTY, 1);
         }
 
         try {

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -277,11 +277,12 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
      * @throws ResponseParsingException When the http response could not be parsed.
      * @throws SynchronisationException When the new data output for the http connection failed to be created.
      * @throws UnauthorizedException If the credentials for the cyface server are wrong.
+     * @throws NetworkErrorException when the connection's input or error stream was null (e.g. connection disabled)
      */
     private String login(final @NonNull String username, final @NonNull String password, SSLContext sslContext)
             throws JSONException, ServerUnavailableException, MalformedURLException, RequestParsingException,
             DataTransmissionException, ResponseParsingException, SynchronisationException, UnauthorizedException,
-            BadRequestException {
+            BadRequestException, NetworkErrorException {
         Log.v(TAG, "Logging in to get new authToken");
 
         // Load authUrl

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -56,7 +56,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.5.0
+ * @version 1.5.1
  * @since 2.0.0
  */
 public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -1,5 +1,7 @@
 package de.cyface.synchronization;
 
+import android.accounts.NetworkErrorException;
+
 import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -63,10 +65,11 @@ interface Http {
      * @throws ResponseParsingException When the http response could not be parsed.
      * @throws SynchronisationException When the new data output for the http connection failed to be created.
      * @throws UnauthorizedException If the credentials for the cyface server are wrong.
+     * @throws NetworkErrorException when the connection's input or error stream was null
      */
     HttpResponse post(HttpURLConnection connection, JSONObject payload, boolean compress)
             throws RequestParsingException, DataTransmissionException, SynchronisationException,
-            ResponseParsingException, UnauthorizedException, BadRequestException;
+            ResponseParsingException, UnauthorizedException, BadRequestException, NetworkErrorException;
 
     /**
      * The serialized post request which transmits a measurement through an existing http connection
@@ -76,6 +79,7 @@ interface Http {
      * @throws UnauthorizedException If the credentials for the cyface server are wrong.
      * @throws BadRequestException When the api responses with {@link HttpURLConnection#HTTP_BAD_REQUEST}
      */
+    @SuppressWarnings("UnusedReturnValue") // May be used in the future
     HttpResponse post(@NonNull HttpURLConnection connection, @NonNull File transferTempFile,
             @NonNull String deviceId, long measurementId, @NonNull String fileName,
             UploadProgressListener progressListener)

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -18,7 +18,7 @@ import androidx.annotation.NonNull;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 3.0.0
  * @since 3.0.0
  */
 interface Http {

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -38,7 +38,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 3.0.0
  * @since 2.0.0
  */
 public class HttpConnection implements Http {

--- a/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
@@ -19,7 +19,7 @@ import de.cyface.utils.Validate;
  * newly connected network.
  *
  * @author Armin Schnabel
- * @version 1.1.3
+ * @version 1.1.4
  * @since 3.0.0
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
@@ -4,7 +4,6 @@ import static de.cyface.synchronization.WiFiSurveyor.TAG;
 
 import android.accounts.Account;
 import android.annotation.TargetApi;
-import android.content.ContentResolver;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
@@ -63,27 +62,17 @@ public class NetworkCallback extends ConnectivityManager.NetworkCallback {
         }
 
         // Syncable ("not metered") filter is already included
-        final boolean syncableConnectionLost = surveyor.synchronizationIsActive()
+        final boolean syncableConnectionLost = surveyor.isPeriodicSyncEnabled()
                 && !surveyor.isConnectedToSyncableNetwork();
-        final boolean syncableConnectionEstablished = !surveyor.synchronizationIsActive()
+        final boolean syncableConnectionEstablished = !surveyor.isPeriodicSyncEnabled()
                 && surveyor.isConnectedToSyncableNetwork();
+
         if (syncableConnectionEstablished) {
-
-            if (!ContentResolver.getMasterSyncAutomatically()) {
-                Log.d(TAG, "connectionEstablished: master sync is disabled. Aborting.");
-                return;
-            }
-
-            // Enable auto-synchronization - periodic flag is always pre set for all account by us
-            Log.v(TAG, "connectionEstablished: setSyncAutomatically.");
-            ContentResolver.setSyncAutomatically(currentSynchronizationAccount, authority, true);
-            surveyor.setSynchronizationIsActive(true);
-
+            Log.v(TAG, "connectionEstablished: setPeriodicSyncEnabled to true");
+            surveyor.setPeriodicSyncEnabled(true);
         } else if (syncableConnectionLost) {
-
-            Log.v(TAG, "connectionLost: setSyncAutomatically to false.");
-            ContentResolver.setSyncAutomatically(currentSynchronizationAccount, authority, false);
-            surveyor.setSynchronizationIsActive(false);
+            Log.v(TAG, "connectionLost: setPeriodicSyncEnabled to false.");
+            surveyor.setPeriodicSyncEnabled(false);
         }
     }
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -43,7 +43,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.4.3
+ * @version 2.5.0
  * @since 2.0.0
  */
 public final class SyncAdapter extends AbstractThreadedSyncAdapter {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -87,7 +87,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
             final @NonNull String authority, final @NonNull ContentProviderClient provider,
             final @NonNull SyncResult syncResult) {
         // The network setting may have changed since the initial sync call, avoid unnecessary serialization
-        if (isAutoSyncDisallowed(account, authority)) {
+        if (isPeriodicSyncDisabled(account, authority)) {
             return;
         }
 
@@ -150,7 +150,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
                         measurement.getIdentifier(), provider, authority);
 
                 // The network setting may have changed since the initial sync call, avoid unnecessary serialization
-                if (isAutoSyncDisallowed(account, authority)) {
+                if (isPeriodicSyncDisabled(account, authority)) {
                     return;
                 }
                 final File compressedTransferTempFile = serializer.writeSerializedCompressed(loader,
@@ -166,7 +166,8 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
                         Validate.notNull(authBundle);
                         jwtAuthToken = authBundle.getString(AccountManager.KEY_AUTHTOKEN);
                     } catch (final NetworkErrorException e) {
-                        // This happened e.g. when Wifi was manually disabled just after synchronization started (Pixel 2 XL).
+                        // This happened e.g. when Wifi was manually disabled just after synchronization started (Pixel
+                        // 2 XL).
                         Log.w(TAG, "getAuthToken failed, was the connection closed? Aborting sync.");
                         return;
                     }
@@ -175,7 +176,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
 
                     // The network setting may have changed since the initial sync call, avoid using metered network
                     // without permission
-                    if (isAutoSyncDisallowed(account, authority)) {
+                    if (isPeriodicSyncDisabled(account, authority)) {
                         return;
                     }
 
@@ -235,20 +236,17 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
      * We need to check if the network is still syncable:
      * - this is only possible indirect, we check if the surveyor disabled auto sync for the account
      * - the network settings could have changed between sync initial call and "now"
-     * - there is a bug [MOV-616] that we were not yet able to fix that SyncService is created and sync starts
-     * when no wifi is connected but mobile data, syncOnUnMeteredNetworkOnly is on, after some time
      *
      * @param account The {@code Account} to check the status for
      * @param authority The authority string for the synchronization to check
      */
-    private boolean isAutoSyncDisallowed(@NonNull final Account account, @NonNull final String authority) {
-
-        final boolean isSyncAllowed = ContentResolver.getSyncAutomatically(account, authority);
-        if (!isSyncAllowed) {
+    private boolean isPeriodicSyncDisabled(@NonNull final Account account, @NonNull final String authority) {
+        final boolean isAllowed = !ContentResolver.getPeriodicSyncs(account, authority).isEmpty();
+        if (!isAllowed) {
             Log.w(TAG,
                     "Sync aborted: auto sync is not enabled for this account (the network is probably metered and syncOnUnMeteredNetworkOnly activated).");
         }
-        return !isSyncAllowed;
+        return !isAllowed;
     }
 
     private void addConnectionListener(final @NonNull ConnectionStatusListener listener) {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncService.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncService.java
@@ -14,7 +14,7 @@ import android.util.Log;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 1.0.7
+ * @version 1.0.8
  * @since 2.0.0
  */
 public final class SyncService extends Service {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncService.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncService.java
@@ -1,7 +1,5 @@
 package de.cyface.synchronization;
 
-import static de.cyface.synchronization.Constants.TAG;
-
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
@@ -22,14 +20,20 @@ import android.util.Log;
 public final class SyncService extends Service {
 
     /**
+     * Logging TAG to identify logs associated with the {@link WiFiSurveyor}.
+     */
+    @SuppressWarnings({"FieldCanBeLocal", "unused"}) // we add and move logs often, so keep it
+    public static final String TAG = Constants.TAG + ".syncsrvc";
+    /**
      * The settings key used to identify the settings storing the URL of the server to upload data to.
      */
     public static final String SYNC_ENDPOINT_URL_SETTINGS_KEY = "de.cyface.sync.endpoint";
     /**
      * The synchronisation adapter this service is supposed to call.
+     * <p>
+     * Singleton isn't what they call a beauty. Nevertheless this is how it is specified in the documentation. Maybe try
+     * to change this after it runs.
      */
-    // Singleton is so ugly. Nevertheless this is how it is specified in the documentation. Maybe try to
-    // change this after it runs.
     private static SyncAdapter syncAdapter = null;
     /**
      * Lock object used to synchronize synchronisation adapter creation as described in the Android documentation.
@@ -38,7 +42,7 @@ public final class SyncService extends Service {
 
     @Override
     public void onCreate() {
-        Log.v(TAG, "sync service on create");
+        Log.v(TAG, "onCreate");
         synchronized (LOCK) {
             if (syncAdapter == null) {
                 syncAdapter = new SyncAdapter(getApplicationContext(), true, new HttpConnection());
@@ -48,7 +52,7 @@ public final class SyncService extends Service {
 
     @Override
     public IBinder onBind(Intent intent) {
-        Log.v(TAG, "sync service on bind");
+        Log.v(TAG, "onBind");
         return syncAdapter.getSyncAdapterBinder();
     }
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -30,7 +30,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.0.1
+ * @version 6.0.0
  * @since 2.0.0
  */
 public class WiFiSurveyor extends BroadcastReceiver {

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -79,10 +79,10 @@ public class WiFiSurveyorTest {
         oocut.startSurveillance(account);
 
         switchWiFiConnection(false);
-        assertThat(oocut.isConnected(), is(equalTo(false)));
+        assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(false)));
 
         switchWiFiConnection(true);
-        assertThat(oocut.isConnected(), is(equalTo(true)));
+        assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(true)));
         assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
     }
 
@@ -102,10 +102,10 @@ public class WiFiSurveyorTest {
         switchMobileConnection(false);
         switchWiFiConnection(false);
         oocut.setSyncOnUnMeteredNetworkOnly(false);
-        assertThat(oocut.isConnected(), is(equalTo(false)));
+        assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(false)));
 
         switchMobileConnection(true);
-        assertThat(oocut.isConnected(), is(equalTo(true)));
+        assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(true)));
         assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
     }
 

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -34,7 +34,7 @@ import androidx.test.core.app.ApplicationProvider;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.1.3
+ * @version 1.1.4
  * @since 2.0.0
  */
 @RunWith(RobolectricTestRunner.class)

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -3,6 +3,7 @@ package de.cyface.synchronization;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static de.cyface.synchronization.TestUtils.ACCOUNT_TYPE;
 import static de.cyface.synchronization.TestUtils.AUTHORITY;
+import static de.cyface.synchronization.WiFiSurveyor.SYNC_INTERVAL;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -23,6 +24,7 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
+import android.os.Bundle;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -72,18 +74,17 @@ public class WiFiSurveyorTest {
     @Test
     public void testWifiConnectivity() throws SynchronisationException {
 
-        // Not sure why this is not set by default (in roboelectric test environment)
-        ContentResolver.setMasterSyncAutomatically(true);
-
         Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
+        ContentResolver.addPeriodicSync(account, AUTHORITY, Bundle.EMPTY, SYNC_INTERVAL);
 
         switchWiFiConnection(false);
         assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(false)));
 
         switchWiFiConnection(true);
         assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(true)));
-        assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
+        assertThat(oocut.isPeriodicSyncEnabled(), is(equalTo(true)));
+        ContentResolver.removePeriodicSync(account, AUTHORITY, Bundle.EMPTY);
     }
 
     /**
@@ -93,11 +94,9 @@ public class WiFiSurveyorTest {
     @Test
     public void testMobileConnectivity() throws SynchronisationException {
 
-        // Not sure why this is not set by default (in roboelectric test environment)
-        ContentResolver.setMasterSyncAutomatically(true);
-
         Account account = oocut.createAccount("test", null);
         oocut.startSurveillance(account);
+        ContentResolver.addPeriodicSync(account, AUTHORITY, Bundle.EMPTY, SYNC_INTERVAL);
 
         switchMobileConnection(false);
         switchWiFiConnection(false);
@@ -106,7 +105,8 @@ public class WiFiSurveyorTest {
 
         switchMobileConnection(true);
         assertThat(oocut.isConnectedToSyncableNetwork(), is(equalTo(true)));
-        assertThat(oocut.synchronizationIsActive(), is(equalTo(true)));
+        assertThat(oocut.isPeriodicSyncEnabled(), is(equalTo(true)));
+        ContentResolver.removePeriodicSync(account, AUTHORITY, Bundle.EMPTY);
     }
 
     /**


### PR DESCRIPTION
Leichtes Refactoring das zum einen:
- [einen Bug aus dem Plan.io behebt](https://stadtradeln.plan.io/issues/1475?issue_count=10&issue_position=3&next_issue_id=1470&prev_issue_id=1474)
- und zum anderen Methoden und Variablen semantisch korrekter benennt
- und alle mir bekannten sync bugs oder tests die mir eingefallen sind erfolgreich absolviert

Mal sehen wie sich das auf anderen Handys/Nutzer bzw. Mittelzeit Tests schlägt.

Das "instantly cancel ongoing sync when syncable network is gone" wie heute im daily erwähnt habe ich nun ins Backlog da das v.a. Resourcen schont für einen Spezialfall (serialization für größere Messung startet, Wifi wird disconnected, aktuell läuft die Serialization dann weiter aber führt keinen Upload durch weil davor in onPerformSync geprüft wird, ob denn noch eine syncable connection besteht.