### PR TITLE
Subtask/stad 82 updatepad testen

### DIFF
--- a/datacapturing/src/androidTestMovebis/java/de/cyface/datacapturing/MovebisTest.java
+++ b/datacapturing/src/androidTestMovebis/java/de/cyface/datacapturing/MovebisTest.java
@@ -18,12 +18,14 @@ import org.junit.runner.RunWith;
 
 import android.Manifest;
 import android.content.Context;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.filters.SdkSuppress;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import de.cyface.datacapturing.exception.SetupException;
+import de.cyface.synchronization.SynchronisationException;
 import de.cyface.utils.CursorIsNullException;
 
 /**
@@ -100,6 +102,27 @@ public final class MovebisTest {
             }
         });
 
+    }
+
+    /**
+     * Tests that registering a JWT auth token (and with that, creating an account) works.
+     * <p>
+     * This tests the code used by movebis and reproduced bug MOV-631
+     *
+     * @throws SynchronisationException This should not happen in the test environment. Occurs if no Android
+     *             <code>Context</code> is available.
+     */
+    @Test
+    public void testRegisterJWTAuthToken() throws SynchronisationException {
+
+        // Arrange
+        final String testUsername = "testUser";
+        final String testToken = "testToken";
+
+        // Act
+        oocut.registerJWTAuthToken(testUsername, testToken);
+
+        // Assert - nothing to do - just making sure no exception is thrown
     }
 
     /**

--- a/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
+++ b/datacapturing/src/movebis/java/de/cyface/datacapturing/MovebisDataCapturingService.java
@@ -231,6 +231,7 @@ public class MovebisDataCapturingService extends DataCapturingService {
         // Create a "dummy" account used for auto synchronization. Null password as the token is static
         final Account synchronizationAccount = getWiFiSurveyor().createAccount(username, null);
 
+        // IntelliJ sometimes cannot resolve AUTH_TOKEN_TYPE: Invalidate cache & restart works.
         accountManager.setAuthToken(synchronizationAccount, AUTH_TOKEN_TYPE, token);
         getWiFiSurveyor().startSurveillance(synchronizationAccount);
     }

--- a/persistence/build.gradle
+++ b/persistence/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$rootProject.ext.mockitoVersion"
     // Optional - For better debuggable asserts
     testImplementation "org.hamcrest:hamcrest-all:$rootProject.ext.hamcrestVersion"
+    testImplementation "org.robolectric:robolectric:$rootProject.ext.robolectricVersion"
+    testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
 
     // Dependencies for instrumentation tests
     //androidTestImplementation project(":testutils") - circular dependency

--- a/persistence/src/androidTest/java/de/cyface/persistence/MeasurementTest.java
+++ b/persistence/src/androidTest/java/de/cyface/persistence/MeasurementTest.java
@@ -1,6 +1,7 @@
 package de.cyface.persistence;
 
 import static de.cyface.persistence.TestUtils.AUTHORITY;
+import static de.cyface.persistence.Utils.getEventUri;
 import static de.cyface.persistence.Utils.getGeoLocationsUri;
 import static de.cyface.persistence.Utils.getMeasurementUri;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -58,6 +59,16 @@ public class MeasurementTest {
         fixtureMeasurement.put(MeasurementTable.COLUMN_PERSISTENCE_FILE_FORMAT_VERSION,
                 MeasurementSerializer.PERSISTENCE_FILE_FORMAT_VERSION);
         fixtureMeasurement.put(MeasurementTable.COLUMN_DISTANCE, 0.0);
+    }
+
+    /**
+     * Shuts down the test and makes sure the database is empty for the next test.
+     */
+    @After
+    public void tearDown() {
+        resolver.delete(getGeoLocationsUri(AUTHORITY), null, null);
+        resolver.delete(getMeasurementUri(AUTHORITY), null, null);
+        resolver.delete(getEventUri(AUTHORITY), null, null);
     }
 
     /**
@@ -124,14 +135,5 @@ public class MeasurementTest {
         ret.put(GeoLocationsTable.COLUMN_SPEED, 1.0);
         ret.put(GeoLocationsTable.COLUMN_ACCURACY, 300);
         return ret;
-    }
-
-    /**
-     * Shuts down the test and makes sure the database is empty for the next test.
-     */
-    @After
-    public void tearDown() {
-        resolver.delete(getGeoLocationsUri(AUTHORITY), null, null);
-        resolver.delete(getMeasurementUri(AUTHORITY), null, null);
     }
 }

--- a/persistence/src/main/java/de/cyface/persistence/AbstractCyfaceMeasurementTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/AbstractCyfaceMeasurementTable.java
@@ -77,7 +77,7 @@ public abstract class AbstractCyfaceMeasurementTable implements CyfaceMeasuremen
     protected abstract String getCreateStatement();
 
     @Override
-    public abstract void onUpgrade(final SQLiteDatabase database, final int oldVersion, final int newVersion);
+    public abstract void onUpgrade(final SQLiteDatabase database, final int fromVersion, final int toVersion);
 
     @Override
     public Cursor query(final SQLiteDatabase database, final String[] projection, final String selection,

--- a/persistence/src/main/java/de/cyface/persistence/CyfaceMeasurementTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/CyfaceMeasurementTable.java
@@ -27,9 +27,12 @@ public interface CyfaceMeasurementTable {
     /**
      * Called during an update of the database. This usually happens if {@code newVersion} is different from
      * {@code oldVersion} and should execute some SQL statements to upgrade the old table format to the new one. If no
-     * changes happened from one version to the other it can stay the same. If you don't care about the data in the
-     * table after an update, you can just delete the old table and create an empty new one. This is the easiest
-     * implementation but you WILL LOSE ALL DATA.
+     * changes happened from one version to the other it can stay the same.
+     * <p>
+     * If you don't care about the data in the table after an update, you can just delete the old table and create an
+     * empty new one. This is the easiest implementation but you WILL LOSE ALL DATA.
+     * <p>
+     * The Upgrade is automatically executed in a transaction, do not wrap the code in another transaction!
      *
      * @param database The database to upgrade the table for.
      * @param oldVersion The prior version number.

--- a/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
+++ b/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
@@ -19,6 +19,7 @@ import de.cyface.persistence.model.Event;
 import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.serialization.Point3dFile;
+import de.cyface.utils.Validate;
 
 /**
  * The <code>DatabaseHelper</code> class is the part of the content provider where the hard part takes place. It
@@ -39,7 +40,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
      * Increase the DATABASE_VERSION if the database structure changes with a new update
      * but don't forget to adjust onCreate and onUpgrade accordingly for the new structure and incremental upgrade
      */
-    private final static int DATABASE_VERSION = 12;
+    private final static int DATABASE_VERSION = 23;
     /**
      * The table containing all the measurements, without the corresponding data. Data is stored in one table per type.
      */
@@ -89,7 +90,10 @@ class DatabaseHelper extends SQLiteOpenHelper {
 
     /**
      * The onUpgrade method is called when the app is upgraded and the DATABASE_VERSION changed.
-     * The incremental database upgrades are executed to reach the current version.
+     * <p>
+     * This method is not called incrementally by the system which is why this method implements this.
+     * <p>
+     * This method is automatically executed in a transaction, do not wrap the code in another transaction!
      *
      * @param database the database which shall be upgraded
      * @param oldVersion the database version the app was in before the upgrade
@@ -97,36 +101,39 @@ class DatabaseHelper extends SQLiteOpenHelper {
      */
     @Override
     public void onUpgrade(final SQLiteDatabase database, final int oldVersion, final int newVersion) {
-        Log.w(TAG, "Upgrading database from version " + oldVersion + " to " + newVersion);
+        Validate.isTrue(oldVersion == 8 || oldVersion >= 11, "Unsupported versions");
 
-        // Incremental upgrades for the tables which don't exist anymore and, thus, don't have an own class file anymore
-        // noinspection SwitchStatementWithTooFewBranches - because others will follow and it's an easier read
-        switch (oldVersion) {
-            case 8:
-                // This upgrade from 8 to 10 is executed for all SDK versions below 3 (which is v 10).
-                // We don't support an soft-upgrade there but reset the database
-                Log.w(TAG, "Upgrading from version " + oldVersion + " to " + newVersion + ": Resetting database");
+        // Upgrade incrementally to reduce the amount of migration code required
+        for (int fromVersion = oldVersion; fromVersion < newVersion; fromVersion++) {
+            final int toVersion = fromVersion + 1;
+            Log.w(TAG, "Upgrading database from version " + fromVersion + " to " + toVersion);
 
-                // We use a transaction as this lead to an unresolvable error where the IdentifierTable
-                // was not created in time for the first database query.
+            // Upgrade code for tables which don't exist anymore as class
+            // noinspection SwitchStatementWithTooFewBranches - because others will follow and it's an easier read
+            switch (fromVersion) {
 
-                // The following tables and table names are deprecated, thus, hard-coded
-                database.execSQL("DELETE FROM sqlite_sequence;");
-                database.execSQL("DELETE FROM sample_points;");
-                database.execSQL("DROP TABLE sample_points;");
-                database.execSQL("DELETE FROM rotation_points;");
-                database.execSQL("DROP TABLE rotation_points;");
-                database.execSQL("DELETE FROM magnetic_value_points;");
-                database.execSQL("DROP TABLE magnetic_value_points;");
-                // continues with the next incremental upgrade until return ! -->
+                case 8:
+                    // Upgrade from V8 which was the last version in SDK V2.
+                    // We don't support a data preserving upgrade for sensor data stored in the database
+                    Log.w(TAG, "Dropping sensor data from database");
+
+                    // The following tables and table names are deprecated, thus, hard-coded
+                    // database.execSQL("DELETE FROM sqlite_sequence;");
+                    database.execSQL("DELETE FROM sample_points;");
+                    database.execSQL("DROP TABLE sample_points;");
+                    database.execSQL("DELETE FROM rotation_points;");
+                    database.execSQL("DROP TABLE rotation_points;");
+                    database.execSQL("DELETE FROM magnetic_value_points;");
+                    database.execSQL("DROP TABLE magnetic_value_points;");
+                    break; // upgrades are called incrementally
+            }
+
+            // Incremental upgrades for existing tables
+            measurementTable.onUpgrade(database, fromVersion, toVersion);
+            geoLocationsTable.onUpgrade(database, fromVersion, toVersion);
+            identifierTable.onUpgrade(database, fromVersion, toVersion);
+            eventTable.onUpgrade(database, fromVersion, toVersion);
         }
-
-        // Incremental upgrades for existing tables
-        // tables contains each table 2 times. We do need to call onUpgrade only once per table
-        measurementTable.onUpgrade(database, oldVersion, newVersion);
-        geoLocationsTable.onUpgrade(database, oldVersion, newVersion);
-        identifierTable.onUpgrade(database, oldVersion, newVersion);
-        eventTable.onUpgrade(database, oldVersion, newVersion);
     }
 
     /**

--- a/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
+++ b/persistence/src/main/java/de/cyface/persistence/DatabaseHelper.java
@@ -40,7 +40,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
      * Increase the DATABASE_VERSION if the database structure changes with a new update
      * but don't forget to adjust onCreate and onUpgrade accordingly for the new structure and incremental upgrade
      */
-    private final static int DATABASE_VERSION = 23;
+    private final static int DATABASE_VERSION = 12;
     /**
      * The table containing all the measurements, without the corresponding data. Data is stored in one table per type.
      */
@@ -125,6 +125,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
                     database.execSQL("DROP TABLE rotation_points;");
                     database.execSQL("DELETE FROM magnetic_value_points;");
                     database.execSQL("DROP TABLE magnetic_value_points;");
+
                     break; // upgrades are called incrementally
             }
 

--- a/persistence/src/main/java/de/cyface/persistence/EventTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/EventTable.java
@@ -55,17 +55,22 @@ public class EventTable extends AbstractCyfaceMeasurementTable {
 
     /**
      * Don't forget to update the {@link DatabaseHelper}'s {@code DATABASE_VERSION} if you upgrade this table.
-     *
-     * Remaining documentation: {@link AbstractCyfaceMeasurementTable#onUpgrade}
+     * <p>
+     * The Upgrade is automatically executed in a transaction, do not wrap the code in another transaction!
+     * <p>
+     * This upgrades are called incrementally by {@link DatabaseHelper#onUpgrade(SQLiteDatabase, int, int)}.
+     * <p>
+     * Remaining documentation: {@link CyfaceMeasurementTable#onUpgrade}
      */
     @Override
-    public void onUpgrade(final SQLiteDatabase database, final int oldVersion, final int newVersion) {
+    public void onUpgrade(final SQLiteDatabase database, final int fromVersion, final int toVersion) {
 
-        // noinspection SwitchStatementWithTooFewBranches - because others will follow and it's an easier read
-        switch (oldVersion) {
+        switch (fromVersion) {
+
             case 11:
+                // This table was added in version 12
                 onCreate(database);
-                // continues with the next incremental upgrade until return ! -->
+                break; // onUpgrade is called incrementally by DatabaseHelper
         }
 
     }

--- a/persistence/src/main/java/de/cyface/persistence/GeoLocationsTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/GeoLocationsTable.java
@@ -95,6 +95,9 @@ public class GeoLocationsTable extends AbstractCyfaceMeasurementTable {
                 database.execSQL("INSERT INTO locations " + "(_id,gps_time,lat,lon,speed,accuracy,measurement_fk) "
                         + "SELECT _id,gps_time,lat,lon,speed,accuracy,measurement_fk " + "FROM _locations_old");
 
+                // Remove temp table
+                database.execSQL("DROP TABLE _locations_old;");
+
                 break; // onUpgrade is called incrementally by DatabaseHelper
         }
 

--- a/persistence/src/main/java/de/cyface/persistence/IdentifierTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/IdentifierTable.java
@@ -43,19 +43,23 @@ public final class IdentifierTable extends AbstractCyfaceMeasurementTable {
 
     /**
      * Don't forget to update the {@link DatabaseHelper}'s {@code DATABASE_VERSION} if you upgrade this table.
-     *
-     * Remaining documentation: {@link AbstractCyfaceMeasurementTable#onUpgrade}
+     * <p>
+     * The Upgrade is automatically executed in a transaction, do not wrap the code in another transaction!
+     * <p>
+     * This upgrades are called incrementally by {@link DatabaseHelper#onUpgrade(SQLiteDatabase, int, int)}.
+     * <p>
+     * Remaining documentation: {@link CyfaceMeasurementTable#onUpgrade}
      */
     @Override
-    public void onUpgrade(@NonNull final SQLiteDatabase database, final int oldVersion, final int newVersion) {
+    public void onUpgrade(@NonNull final SQLiteDatabase database, final int fromVersion, final int toVersion) {
 
         // noinspection SwitchStatementWithTooFewBranches - because others will follow and it's an easier read
-        switch (oldVersion) {
-            case 8:
-                // This upgrade from 8 to 10 is executed for all SDK versions below 3 (which is v 10).
-                // We don't support an soft-upgrade there but reset the database
+        switch (fromVersion) {
+
+            case 9:
+                // This table was added in version 10
                 onCreate(database);
-                // continues with the next incremental upgrade until return ! -->
+                break; // onUpgrade is called incrementally by DatabaseHelper
         }
     }
 

--- a/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
@@ -118,7 +118,7 @@ public class MeasurementTable extends AbstractCyfaceMeasurementTable {
 
                 // Distance column was added. Calculate the distance for existing entries.
                 database.execSQL("ALTER TABLE _measurements_old ADD COLUMN distance REAL NOT NULL DEFAULT 0.0;");
-                // FIXME: calculate distance for old entries!
+                // FIXME: calculate distance for old entries! - update test, too
 
                 // Columns "finished" and "synced" are now in the "status" column
                 // To migrate old measurements we need to set a default which is then adjusted

--- a/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
+++ b/persistence/src/main/java/de/cyface/persistence/MeasurementTable.java
@@ -100,11 +100,12 @@ public class MeasurementTable extends AbstractCyfaceMeasurementTable {
                 database.execSQL("ALTER TABLE measurement RENAME TO _measurements_old;");
 
                 // Due to a bug in the code of V8 MeasurementTable we may need to create the sync column
+                /* This should never be the case for STAD-2019
                 try {
                     database.execSQL("ALTER TABLE _measurements_old ADD COLUMN synced INTEGER NOT NULL DEFAULT 0");
                 } catch (final SQLiteException ex) {
                     Log.w(TAG, "Altering measurements: " + ex.getMessage());
-                }
+                }*/
 
                 // Columns "accelerations", "rotations", and "directions" were added
                 // We don't support a data preserving upgrade for sensor data stored in the database
@@ -137,6 +138,9 @@ public class MeasurementTable extends AbstractCyfaceMeasurementTable {
                         "(_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) "+
                         "SELECT _id,status,vehicle,accelerations,rotations,directions,file_format_version,distance "+
                         "FROM _measurements_old");
+
+                // Remove temp table
+                database.execSQL("DROP TABLE _measurements_old;");
 
                 break; // onUpgrade is called incrementally by DatabaseHelper
         }

--- a/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
+++ b/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
@@ -5,19 +5,11 @@ import static de.cyface.persistence.Utils.getEventUri;
 import static de.cyface.persistence.Utils.getGeoLocationsUri;
 import static de.cyface.persistence.Utils.getIdentifierUri;
 import static de.cyface.persistence.Utils.getMeasurementUri;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -30,9 +22,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQuery;
 
 import androidx.test.core.app.ApplicationProvider;
-import de.cyface.persistence.model.Measurement;
-import de.cyface.persistence.model.Track;
-import de.cyface.utils.CursorIsNullException;
 
 /**
  * This class tests the migration functionality of {@link DatabaseHelper}.
@@ -46,33 +35,27 @@ import de.cyface.utils.CursorIsNullException;
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE) // Or do we need one?
-//@Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK)
+// @Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK)
 public class DatabaseHelperTest {
 
     /**
      * We require Mockito to avoid calling Android system functions. This rule is responsible for the initialization of
      * the Spies and Mocks.
      */
-    //@Rule
-    //public MockitoRule mockitoRule = MockitoJUnit.rule();
+    // @Rule
+    // public MockitoRule mockitoRule = MockitoJUnit.rule();
     private SQLiteDatabase db;
     /**
      * The object of the class under test
      */
     private DatabaseHelper oocut;
-    /**
-     * The Android test <code>Context</code> to use for testing.
-     */
-    private Context context;
     private ContentResolver resolver;
-    PersistenceLayer<DefaultPersistenceBehaviour> persistenceLayer;
 
     @Before
     public void setUp() {
-        context = ApplicationProvider.getApplicationContext();
+        Context context = ApplicationProvider.getApplicationContext();
         resolver = context.getContentResolver();
         oocut = new DatabaseHelper(context);
-        persistenceLayer = new PersistenceLayer<>(context, resolver, AUTHORITY, new DefaultPersistenceBehaviour());
 
         // Clearing database just in case
         resolver.delete(getIdentifierUri(AUTHORITY), null, null);
@@ -80,13 +63,11 @@ public class DatabaseHelperTest {
         resolver.delete(getMeasurementUri(AUTHORITY), null, null);
         resolver.delete(getEventUri(AUTHORITY), null, null);
 
-        // Sample:
-        // mContext = new RenamingDelegatingContext(context, "db_helper_test_");
         SQLiteDatabase.CursorFactory cursorFactory = new SQLiteDatabase.CursorFactory() {
             @Override
             public Cursor newCursor(final SQLiteDatabase db, final SQLiteCursorDriver masterQuery,
                     final String editTable, final SQLiteQuery query) {
-                return new SQLiteCursor(db, masterQuery, editTable, query);
+                return new SQLiteCursor(masterQuery, editTable, query);
             }
         };
         db = SQLiteDatabase.create(cursorFactory);
@@ -108,7 +89,7 @@ public class DatabaseHelperTest {
      * Test that changing a single column value for a geo location works as expected.
      */
     @Test
-    public void testMigrationV11ToV12() throws CursorIsNullException, NoDeviceIdException {
+    public void testMigrationV11ToV12() {
 
         // Arrange
         createV11DatabaseWithData(db);

--- a/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
+++ b/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
@@ -41,8 +41,6 @@ public class DatabaseHelperTest {
      * We require Mockito to avoid calling Android system functions. This rule is responsible for the initialization of
      * the Spies and Mocks.
      */
-    // @Rule
-    // public MockitoRule mockitoRule = MockitoJUnit.rule();
     private SQLiteDatabase db;
     /**
      * The object of the class under test
@@ -108,15 +106,12 @@ public class DatabaseHelperTest {
      * after upgrading from the V2 SDK version which was included in the first official STAD release (#776b323540).
      * <p>
      * The database upgrade V12 was part of (STAD-6)!
-     * <p>
-     * FIXME: THIS TEST MUST MAKE SURE MEASUREMENTS AND GPS POINTS FROM V8 are not deleted on Upgrade!
      */
     @Test
     public void testMigrationV8ToV12() {
 
         // Arrange
         createV8DatabaseWithData(db);
-        // FIXME: try with and without measurement.sync column
 
         // Act - This is how the method is called by the system (not incrementally!)
         oocut.onUpgrade(db, 8, 12);
@@ -177,7 +172,7 @@ public class DatabaseHelperTest {
         // # Create V11 Tables:
 
         // Create android_metadata table (exists in SQLite export)
-        db.execSQL("DROP TABLE IF EXISTS `android_metadata`");
+        db.execSQL("DROP TABLE IF EXISTS android_metadata");
         db.execSQL("CREATE TABLE android_metadata (locale TEXT);");
         // Create IdentifierTable
         db.execSQL("CREATE TABLE identifiers (_id INTEGER PRIMARY KEY AUTOINCREMENT, device_id TEXT NOT NULL);");
@@ -198,7 +193,7 @@ public class DatabaseHelperTest {
         db.execSQL("INSERT INTO identifiers (_id,device_id) VALUES (1,'61e112e1-548e-4a90-be28-9d5b31d6875b');");
         // Insert sample MeasurementTable entries - execSQL only supports one insert per commend
         db.execSQL(
-                "INSERT INTO `measurements` (_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) VALUES "
+                "INSERT INTO measurements (_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) VALUES "
                         + " (43,'FINISHED','BICYCLE',690481,690336,166370,1,5396.62473698979);");
         // Insert sample GeoLocationsTable entries - execSQL only supports one insert per commend
         db.execSQL("INSERT INTO locations (_id,gps_time,lat,lon,speed,accuracy,measurement_fk) VALUES "
@@ -219,9 +214,11 @@ public class DatabaseHelperTest {
         // # Create V8 Tables:
 
         // Create android_metadata table (exists in SQLite export)
-        db.execSQL("DROP TABLE IF EXISTS `android_metadata`");
+        db.execSQL("DROP TABLE IF EXISTS android_metadata");
         db.execSQL("CREATE TABLE android_metadata (locale TEXT);");
         // Create MeasurementTable
+        // In the V8 MeasurementTable.onUpgrade code there is a bug but it is never executed
+        // as a fresh V8 is installed for early 2019 STAD users and the old upgrade code is never executed.
         db.execSQL(
                 "CREATE TABLE measurement(_id INTEGER PRIMARY KEY AUTOINCREMENT, finished INTEGER NOT NULL DEFAULT 1, "
                         + "vehicle TEXT, synced INTEGER NOT NULL DEFAULT 0);");

--- a/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
+++ b/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
@@ -34,8 +34,7 @@ import androidx.test.core.app.ApplicationProvider;
  * @since 4.0.0
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE) // Or do we need one?
-// @Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK)
+@Config(manifest = Config.NONE) // To avoid warning
 public class DatabaseHelperTest {
 
     /**
@@ -86,37 +85,6 @@ public class DatabaseHelperTest {
     }
 
     /**
-     * Test that loading the EventTable which was introduced in the Database V12 Upgrade works
-     * after upgrading from the V2 SDK version which was included in the first official STAD release (#776b323540).
-     * <p>
-     * The database upgrade V12 was part of (STAD-6)!
-     */
-    @Test
-    public void testMigrationV8ToV12() {
-
-        // Arrange
-        createV8DatabaseWithData(db);
-
-        // Act
-        // The old code had the following special onUpgrade line:
-        /*
-         * --MeasurementTable--
-         * case 8:
-         * database.beginTransaction();
-         * database.execSQL(
-         * "ALTER TABLE " + getName() + " ADD COLUMN " + COLUMN_SYNCED + " INTEGER NOT NULL DEFAULT 0;");
-         */
-        oocut.onUpgrade(db, 8, 9);
-        oocut.onUpgrade(db, 9, 10);
-        oocut.onUpgrade(db, 10, 11);
-        oocut.onUpgrade(db, 11, 12);
-
-        // Assert
-        // Loading from the newly added table must work (STAD-85)
-        db.execSQL("SELECT * FROM events;");
-    }
-
-    /**
      * Test that loading the EventTable which was introduced in the Database V12 Upgrade works.
      * <p>
      * This database upgrade V12 was part of (STAD-6)!
@@ -127,12 +95,114 @@ public class DatabaseHelperTest {
         // Arrange
         createV11DatabaseWithData(db);
 
-        // Act
+        // Act - This is how the method is called by the system (not incrementally!)
         oocut.onUpgrade(db, 11, 12);
 
         // Assert
         // Loading from the newly added table must work (STAD-85)
         db.execSQL("SELECT * FROM events;");
+    }
+
+    /**
+     * Test that loading the EventTable which was introduced in the Database V12 Upgrade works
+     * after upgrading from the V2 SDK version which was included in the first official STAD release (#776b323540).
+     * <p>
+     * The database upgrade V12 was part of (STAD-6)!
+     * <p>
+     * FIXME: THIS TEST MUST MAKE SURE MEASUREMENTS AND GPS POINTS FROM V8 are not deleted on Upgrade!
+     */
+    @Test
+    public void testMigrationV8ToV12() {
+
+        // Arrange
+        createV8DatabaseWithData(db);
+        // FIXME: try with and without measurement.sync column
+
+        // Act - This is how the method is called by the system (not incrementally!)
+        oocut.onUpgrade(db, 8, 12);
+
+        // Assert
+        // Loading from the newly added table must work (STAD-85)
+        db.execSQL("SELECT * FROM events;");
+    }
+
+    /**
+     * Test that creating a fresh database for the current database version works as expected.
+     * <p>
+     * Should be okay to only test this (always) for the current version at the time of execution
+     * as an older database version is never created when there is already a newer version.
+     */
+    @Test
+    public void testCreateCurrentVersion() {
+
+        // Arrange - nothing to do
+
+        // Act
+        oocut.onCreate(db);
+
+        // Assert - currently only checking that there is not exception
+    }
+
+    private void createV12Database(SQLiteDatabase db) {
+        throw new IllegalStateException("no yet implemented");
+        // This is simpler than duplicating the code from last version
+        // createV11DatabaseWithData(db);
+        // oocut.onUpgrade(db, 11, 12);
+
+        // Here the sample code from an V12 export for the next migration test
+        /*
+         * CREATE TABLE events (
+         * _id INTEGER PRIMARY KEY AUTOINCREMENT,
+         * timestamp INTEGER NOT NULL,
+         * type TEXT NOT NULL,
+         * measurement_fk INTEGER
+         * );
+         * INSERT INTO events (_id,timestamp,type,measurement_fk) VALUES (7,1552322118501,'LIFECYCLE_START',25),
+         * (8,1552323369059,'LIFECYCLE_STOP',25),
+         * (17,1552412961053,'LIFECYCLE_START',30),
+         */
+    }
+
+    /**
+     * Creates a database as it would have been created with {@link DatabaseHelper#DATABASE_VERSION} 11.
+     * <p>
+     * <b>Attention:</b>
+     * It's important that the create statements only contains hardcoded Strings as the table and column names
+     * should be the same as they were in that version to really test the migration as it would happen in real.
+     *
+     * @param db A clean {@link SQLiteDatabase} to use for testing.
+     */
+    private void createV11DatabaseWithData(SQLiteDatabase db) {
+
+        // # Create V11 Tables:
+
+        // Create android_metadata table (exists in SQLite export)
+        db.execSQL("DROP TABLE IF EXISTS `android_metadata`");
+        db.execSQL("CREATE TABLE android_metadata (locale TEXT);");
+        // Create IdentifierTable
+        db.execSQL("CREATE TABLE identifiers (_id INTEGER PRIMARY KEY AUTOINCREMENT, device_id TEXT NOT NULL);");
+        // Create MeasurementTable
+        db.execSQL("CREATE TABLE measurements (_id INTEGER PRIMARY KEY AUTOINCREMENT, status TEXT NOT NULL, "
+                + "vehicle TEXT NOT NULL, accelerations INTEGER NOT NULL, rotations INTEGER NOT NULL, "
+                + "directions INTEGER NOT NULL, file_format_version INTEGER NOT NULL, distance REAL NOT NULL);");
+        // Create GeoLocationsTable
+        db.execSQL("CREATE TABLE locations (_id INTEGER PRIMARY KEY AUTOINCREMENT, gps_time INTEGER NOT NULL, "
+                + "lat REAL NOT NULL, lon REAL NOT NULL, speed REAL NOT NULL, accuracy INTEGER NOT NULL, "
+                + "measurement_fk INTEGER NOT NULL);");
+
+        // # Insert V11 sample data: (exported from our V12 app and manually adjusted to V11)
+
+        // Insert sample android_metadata table entry (exists in SQLite export)
+        db.execSQL("INSERT INTO android_metadata (locale) VALUES ('de_DE');");
+        // Insert sample IdentifierTable entry
+        db.execSQL("INSERT INTO identifiers (_id,device_id) VALUES (1,'61e112e1-548e-4a90-be28-9d5b31d6875b');");
+        // Insert sample MeasurementTable entries - execSQL only supports one insert per commend
+        db.execSQL(
+                "INSERT INTO `measurements` (_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) VALUES "
+                        + " (43,'FINISHED','BICYCLE',690481,690336,166370,1,5396.62473698979);");
+        // Insert sample GeoLocationsTable entries - execSQL only supports one insert per commend
+        db.execSQL("INSERT INTO locations (_id,gps_time,lat,lon,speed,accuracy,measurement_fk) VALUES "
+                + " (3,1551431485000,51.05210394,13.72873203,0.0,1179,43);");
     }
 
     /**
@@ -146,7 +216,7 @@ public class DatabaseHelperTest {
      */
     private void createV8DatabaseWithData(SQLiteDatabase db) {
 
-        // Create V8 Tables:
+        // # Create V8 Tables:
 
         // Create android_metadata table (exists in SQLite export)
         db.execSQL("DROP TABLE IF EXISTS `android_metadata`");
@@ -172,95 +242,25 @@ public class DatabaseHelperTest {
                 + "my REAL NOT NULL, mz REAL NOT NULL, time INTEGER NOT NULL, measurement_fk INTEGER NOT NULL, "
                 + "is_synced INTEGER NOT NULL DEFAULT 0);");
 
-        // Insert V8 sample data:
+        // # Insert V8 sample data: (sql manually written as we did not use > V6 in our own app)
 
         // Insert sample android_metadata table entry (exists in SQLite export)
         db.execSQL("INSERT INTO android_metadata (locale) VALUES ('de_DE');");
-        // Insert sample IdentifierTable entry
-        db.execSQL("INSERT INTO identifiers (_id,device_id) VALUES (1,'61e112e1-548e-4a90-be28-9d5b31d6875b');");
         // Insert sample MeasurementTable entries - execSQL only supports one insert per commend
-        db.execSQL(
-                "INSERT INTO `measurements` (_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) VALUES "
-                        + " (43,'FINISHED','BICYCLE',690481,690336,166370,1,5396.62473698979);");
+        db.execSQL("INSERT INTO measurement (_id,finished,vehicle,synced) VALUES (42,1,'BICYCLE',1);");
+        db.execSQL("INSERT INTO measurement (_id,finished,vehicle,synced) VALUES (43,1,'BICYCLE',0);");
+        db.execSQL("INSERT INTO measurement (_id,finished,vehicle,synced) VALUES (44,0,'BICYCLE',0);");
         // Insert sample GeoLocationsTable entries - execSQL only supports one insert per commend
-        db.execSQL("INSERT INTO locations (_id,gps_time,lat,lon,speed,accuracy,measurement_fk) VALUES "
-                + " (3,1551431485000,51.05210394,13.72873203,0.0,1179,43);");
-    }
-
-    /**
-     * Creates a database as it would have been created with {@link DatabaseHelper#DATABASE_VERSION} 11.
-     * <p>
-     * <b>Attention:</b>
-     * It's important that the create statements only contains hardcoded Strings as the table and column names
-     * should be the same as they were in that version to really test the migration as it would happen in real.
-     *
-     * @param db A clean {@link SQLiteDatabase} to use for testing.
-     */
-    private void createV11DatabaseWithData(SQLiteDatabase db) {
-
-        // Create V11 Tables:
-        // Create android_metadata table (exists in SQLite export)
-        db.execSQL("DROP TABLE IF EXISTS `android_metadata`");
-        db.execSQL("CREATE TABLE android_metadata (locale TEXT);");
-        // Create IdentifierTable
-        db.execSQL("CREATE TABLE identifiers (_id INTEGER PRIMARY KEY AUTOINCREMENT, device_id TEXT NOT NULL);");
-        // Create MeasurementTable
-        db.execSQL("CREATE TABLE measurements (_id INTEGER PRIMARY KEY AUTOINCREMENT, status TEXT NOT NULL, "
-                + "vehicle TEXT NOT NULL, accelerations INTEGER NOT NULL, rotations INTEGER NOT NULL, "
-                + "directions INTEGER NOT NULL, file_format_version SHORT INTEGER NOT NULL, distance REAL NOT NULL);");
-        // Create GeoLocationsTable
-        db.execSQL("CREATE TABLE locations (_id INTEGER PRIMARY KEY AUTOINCREMENT, gps_time INTEGER NOT NULL, "
-                + "lat REAL NOT NULL, lon REAL NOT NULL, speed REAL NOT NULL, accuracy INTEGER NOT NULL, "
-                + "measurement_fk INTEGER NOT NULL);");
-
-        // Insert V11 sample data:
-        // Insert sample android_metadata table entry (exists in SQLite export)
-        db.execSQL("INSERT INTO android_metadata (locale) VALUES ('de_DE');");
-        // Insert sample IdentifierTable entry
-        db.execSQL("INSERT INTO identifiers (_id,device_id) VALUES (1,'61e112e1-548e-4a90-be28-9d5b31d6875b');");
-        // Insert sample MeasurementTable entries - execSQL only supports one insert per commend
-        db.execSQL(
-                "INSERT INTO `measurements` (_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) VALUES "
-                        + " (43,'FINISHED','BICYCLE',690481,690336,166370,1,5396.62473698979);");
-        // Insert sample GeoLocationsTable entries - execSQL only supports one insert per commend
-        db.execSQL("INSERT INTO locations (_id,gps_time,lat,lon,speed,accuracy,measurement_fk) VALUES "
-                + " (3,1551431485000,51.05210394,13.72873203,0.0,1179,43);");
-    }
-
-    private void createV12Database(SQLiteDatabase db) {
-        throw new IllegalStateException("no yet implemented");
-        // This is simpler than duplicating the code from last version
-        // createV11DatabaseWithData(db);
-        // oocut.onUpgrade(db, 11, 12);
-
-        // Here the sample code from an V12 export for the next migration test
-        /*
-         * CREATE TABLE events (
-         * _id INTEGER PRIMARY KEY AUTOINCREMENT,
-         * timestamp INTEGER NOT NULL,
-         * type TEXT NOT NULL,
-         * measurement_fk INTEGER
-         * );
-         * INSERT INTO events (_id,timestamp,type,measurement_fk) VALUES (7,1552322118501,'LIFECYCLE_START',25),
-         * (8,1552323369059,'LIFECYCLE_STOP',25),
-         * (17,1552412961053,'LIFECYCLE_START',30),
-         */
-    }
-
-    /**
-     * Test that creating a fresh database for the current database version works as expected.
-     * <p>
-     * Should be okay to only test this (always) for the current version at the time of execution
-     * as an older database version is never created when there is already a newer version.
-     */
-    @Test
-    public void testCreateCurrentVersion() {
-
-        // Arrange - nothing to do
-
-        // Act
-        oocut.onCreate(db);
-
-        // Assert - currently only checking that there is not exception
+        db.execSQL("INSERT INTO gps_points (_id,gps_time,lat,lon,speed,accuracy,measurement_fk,is_synced) VALUES "
+                + " (3,1551431485000,51.05210394,13.72873203,0.0,1179,43,0);");
+        // Insert sample SamplePointTable entries - execSQL only supports one insert per commend
+        db.execSQL("INSERT INTO sample_points (_id,ax,ay,az,time,measurement_fk,is_synced) VALUES "
+                + " (101,0.123,0.234,-0.321,1552917550000,43,0);");
+        // Insert sample RotationPointTable entries - execSQL only supports one insert per commend
+        db.execSQL("INSERT INTO rotation_points (_id,rx,ry,rz,time,measurement_fk,is_synced) VALUES "
+                + " (101,0.123,0.234,-0.321,1552917550000,43,0);");
+        // Insert sample MagneticValuePointTable entries - execSQL only supports one insert per commend
+        db.execSQL("INSERT INTO magnetic_value_points (_id,mx,my,mz,time,measurement_fk,is_synced) VALUES "
+                + " (101,0.123,0.234,-0.321,1552917550000,43,0);");
     }
 }

--- a/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
+++ b/persistence/src/test/java/de/cyface/persistence/DatabaseHelperTest.java
@@ -1,0 +1,198 @@
+package de.cyface.persistence;
+
+import static de.cyface.persistence.TestUtils.AUTHORITY;
+import static de.cyface.persistence.Utils.getEventUri;
+import static de.cyface.persistence.Utils.getGeoLocationsUri;
+import static de.cyface.persistence.Utils.getIdentifierUri;
+import static de.cyface.persistence.Utils.getMeasurementUri;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteCursor;
+import android.database.sqlite.SQLiteCursorDriver;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteQuery;
+
+import androidx.test.core.app.ApplicationProvider;
+import de.cyface.persistence.model.Measurement;
+import de.cyface.persistence.model.Track;
+import de.cyface.utils.CursorIsNullException;
+
+/**
+ * This class tests the migration functionality of {@link DatabaseHelper}.
+ * <p>
+ * To create database the sample data SQL you can capture data with the app, export the SQLite database,
+ * open it with *DB Browser for SQLite* and use File > Export > Database to SQL file.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.0
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE) // Or do we need one?
+//@Config(constants = BuildConfig.class, sdk = DefaultConfig.EMULATE_SDK)
+public class DatabaseHelperTest {
+
+    /**
+     * We require Mockito to avoid calling Android system functions. This rule is responsible for the initialization of
+     * the Spies and Mocks.
+     */
+    //@Rule
+    //public MockitoRule mockitoRule = MockitoJUnit.rule();
+    private SQLiteDatabase db;
+    /**
+     * The object of the class under test
+     */
+    private DatabaseHelper oocut;
+    /**
+     * The Android test <code>Context</code> to use for testing.
+     */
+    private Context context;
+    private ContentResolver resolver;
+    PersistenceLayer<DefaultPersistenceBehaviour> persistenceLayer;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        resolver = context.getContentResolver();
+        oocut = new DatabaseHelper(context);
+        persistenceLayer = new PersistenceLayer<>(context, resolver, AUTHORITY, new DefaultPersistenceBehaviour());
+
+        // Clearing database just in case
+        resolver.delete(getIdentifierUri(AUTHORITY), null, null);
+        resolver.delete(getGeoLocationsUri(AUTHORITY), null, null);
+        resolver.delete(getMeasurementUri(AUTHORITY), null, null);
+        resolver.delete(getEventUri(AUTHORITY), null, null);
+
+        // Sample:
+        // mContext = new RenamingDelegatingContext(context, "db_helper_test_");
+        SQLiteDatabase.CursorFactory cursorFactory = new SQLiteDatabase.CursorFactory() {
+            @Override
+            public Cursor newCursor(final SQLiteDatabase db, final SQLiteCursorDriver masterQuery,
+                    final String editTable, final SQLiteQuery query) {
+                return new SQLiteCursor(db, masterQuery, editTable, query);
+            }
+        };
+        db = SQLiteDatabase.create(cursorFactory);
+    }
+
+    /**
+     * Clean the database after each test.
+     */
+    @After
+    public void tearDown() {
+        resolver.delete(getGeoLocationsUri(AUTHORITY), null, null);
+        resolver.delete(getMeasurementUri(AUTHORITY), null, null);
+        resolver.delete(getEventUri(AUTHORITY), null, null);
+        resolver.delete(getIdentifierUri(AUTHORITY), null, null);
+        db.close();
+    }
+
+    /**
+     * Test that changing a single column value for a geo location works as expected.
+     */
+    @Test
+    public void testMigrationV11ToV12() throws CursorIsNullException, NoDeviceIdException {
+
+        // Arrange
+        createV11DatabaseWithData(db);
+
+        // Act
+        oocut.onUpgrade(db, 11, 12);
+
+        // Assert - currently only checking that there is not exception
+    }
+
+    /**
+     * Creates a database as it would have been created with {@link DatabaseHelper#DATABASE_VERSION} 11.
+     * <p>
+     * <b>Attention:</b>
+     * It's important that the create statements only contains hardcoded Strings as the table and column names
+     * should be the same as they were in that version to really test the migration as it would happen in real.
+     *
+     * @param db A clean {@link SQLiteDatabase} to use for testing.
+     */
+    private void createV11DatabaseWithData(SQLiteDatabase db) {
+
+        // Create V11 Tables:
+        // Create android_metadata table (exists in SQLite export)
+        db.execSQL("DROP TABLE IF EXISTS `android_metadata`");
+        db.execSQL("CREATE TABLE android_metadata (locale TEXT);");
+        // Create IdentifierTable
+        db.execSQL("CREATE TABLE identifiers (_id INTEGER PRIMARY KEY AUTOINCREMENT, device_id TEXT NOT NULL);");
+        // Create MeasurementTable
+        db.execSQL("CREATE TABLE measurements (_id INTEGER PRIMARY KEY AUTOINCREMENT, status TEXT NOT NULL, "
+                + "vehicle TEXT NOT NULL, accelerations INTEGER NOT NULL, rotations INTEGER NOT NULL, "
+                + "directions INTEGER NOT NULL, file_format_version SHORT INTEGER NOT NULL, distance REAL NOT NULL);");
+        // Create GeoLocationsTable
+        db.execSQL("CREATE TABLE locations (_id INTEGER PRIMARY KEY AUTOINCREMENT, gps_time INTEGER NOT NULL, "
+                + "lat REAL NOT NULL, lon REAL NOT NULL, speed REAL NOT NULL, accuracy INTEGER NOT NULL, "
+                + "measurement_fk INTEGER NOT NULL);");
+
+        // Insert V11 sample data:
+        // Insert sample android_metadata table entry (exists in SQLite export)
+        db.execSQL("INSERT INTO android_metadata (locale) VALUES ('de_DE');");
+        // Insert sample IdentifierTable entry
+        db.execSQL("INSERT INTO identifiers (_id,device_id) VALUES (1,'61e112e1-548e-4a90-be28-9d5b31d6875b');");
+        // Insert sample MeasurementTable entries - execSQL only supports one insert per commend
+        db.execSQL(
+                "INSERT INTO `measurements` (_id,status,vehicle,accelerations,rotations,directions,file_format_version,distance) VALUES "
+                        + " (43,'FINISHED','BICYCLE',690481,690336,166370,1,5396.62473698979);");
+        // Insert sample GeoLocationsTable entries - execSQL only supports one insert per commend
+        db.execSQL("INSERT INTO locations (_id,gps_time,lat,lon,speed,accuracy,measurement_fk) VALUES "
+                + " (3,1551431485000,51.05210394,13.72873203,0.0,1179,43);");
+    }
+
+    private void createV12Database(SQLiteDatabase db) {
+        throw new IllegalStateException("no yet implemented");
+        // This is simpler than duplicating the code from last version
+        // createV11DatabaseWithData(db);
+        // oocut.onUpgrade(db, 11, 12);
+
+        // Here the sample code from an V12 export for the next migration test
+        /*
+         * CREATE TABLE events (
+         * _id INTEGER PRIMARY KEY AUTOINCREMENT,
+         * timestamp INTEGER NOT NULL,
+         * type TEXT NOT NULL,
+         * measurement_fk INTEGER
+         * );
+         * INSERT INTO events (_id,timestamp,type,measurement_fk) VALUES (7,1552322118501,'LIFECYCLE_START',25),
+         * (8,1552323369059,'LIFECYCLE_STOP',25),
+         * (17,1552412961053,'LIFECYCLE_START',30),
+         */
+    }
+
+    /**
+     * Test that creating a fresh database for the current database version works as expected.
+     * <p>
+     * Should be okay to only test this (always) for the current version at the time of execution
+     * as an older database version is never created when there is already a newer version.
+     */
+    @Test
+    public void testCreateCurrentVersion() {
+
+        // Arrange - nothing to do
+
+        // Act
+        oocut.onCreate(db);
+
+        // Assert - currently only checking that there is not exception
+    }
+}

--- a/persistence/src/test/java/de/cyface/persistence/TestUtils.java
+++ b/persistence/src/test/java/de/cyface/persistence/TestUtils.java
@@ -1,0 +1,27 @@
+package de.cyface.persistence;
+
+/**
+ * Contains constants and utility methods required during testing.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.0
+ */
+public final class TestUtils {
+
+    /**
+     * The content provider authority used for testing.
+     */
+    public final static String AUTHORITY = "de.cyface.persistence.provider.test";
+    /**
+     * The account type used during testing. This must be the same as in the authenticator configuration.
+     */
+    public final static String ACCOUNT_TYPE = "de.cyface.persistence.account.test";
+
+    /**
+     * Private constructor to avoid instantiation of utility class.
+     */
+    private TestUtils() {
+        // Nothing to do here.
+    }
+}

--- a/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.java
@@ -11,7 +11,6 @@ import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import de.cyface.utils.Validate;
 
 /**
  * This callback handles status changes of the {@link Network} connectivity, e.g. to determine if synchronization should
@@ -53,7 +52,11 @@ public class NetworkCallback extends ConnectivityManager.NetworkCallback {
         // Ensure this event is only triggered for not metered connections when syncOnUnMeteredNetworkOnly
         if (surveyor.isSyncOnUnMeteredNetworkOnly()) {
             final boolean notMetered = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED);
-            Validate.isTrue(notMetered);
+            // This should always be the case but for some reasons it's not (Nexus 5)
+            if (!notMetered) {
+                Log.e(TAG, "onCapabilitiesChanged called on metered network with isSyncOnUnMeteredNetworkOnly on");
+                return;
+            }
         }
 
         if (currentSynchronizationAccount == null) {

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -299,8 +299,8 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * - do not use setSyncAutomatically as it behaves not as expected, see MOV-609
      * <p>
      * Synchronization is generally enabled by default. To disabled it *completely*, use
-     * {@link #setSyncEnabled(boolean)}}. The periodic ("auto") sync is set automatically when the network changes
-     * depending on your {@link #setSyncOnUnMeteredNetworkOnly(boolean)} setting which is true by default.
+     * {@link #setSyncEnabled(Account, boolean)}}. The periodic ("auto") sync is set automatically when the network
+     * changes depending on your {@link #setSyncOnUnMeteredNetworkOnly(boolean)} setting which is true by default.
      *
      * @param account The {@code Account} to be used for synchronization
      * @param enabled True if the synchronization should be enabled
@@ -308,7 +308,7 @@ public class WiFiSurveyor extends BroadcastReceiver {
     @SuppressWarnings("unused") // Used by CyfaceDataCapturingService
     public void makeAccountSyncable(@NonNull final Account account, boolean enabled) {
 
-        setSyncEnabled(enabled);
+        setSyncEnabled(account, enabled);
     }
 
     /**
@@ -375,6 +375,8 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * <b>ATTENTION:</b> Starting at version {@code Build.VERSION_CODES.O} and higher instead of
      * treating only "WiFi" connections as "not metered" we use the
      * {@code NetworkCapabilities#NET_CAPABILITY_NOT_METERED} as synonym as suggested by Android.
+     * <p>
+     * This method must be called after {@link #startSurveillance(Account)} is called.
      *
      * @param newState If {@code true} the {@link WiFiSurveyor} synchronizes data only if connected to a
      *            {@code android.net.NetworkCapabilities#NET_CAPABILITY_NOT_METERED} network; if
@@ -402,6 +404,8 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * also triggers {@link #scheduleSyncNow()}.
      * <p>
      * We do not use {@code ContentResolver#setSyncAutomatically()} as it does not behave as expected MOV-609.
+     * <p>
+     * This method must be called after {@link #startSurveillance(Account)} is called.
      *
      * @param newState True if {@code ContentResolver#addPeriodicSync()} should be activated or false if it
      *            should be removed from the sync account.
@@ -416,6 +420,8 @@ public class WiFiSurveyor extends BroadcastReceiver {
     }
 
     /**
+     * This method must be called after {@link #startSurveillance(Account)} is called.
+     *
      * @return A flag that might be queried to see whether synchronization is active or not. This is <code>true</code>
      *         if synchronization is active and <code>false</code> otherwise.
      */
@@ -429,20 +435,41 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * <b>Attention:</b>
      * If you want to check if periodic ("auto") sync is enabled which is automatically set when the network state
      * changes, see {@link #isPeriodicSyncEnabled()}.
+     * <p>
+     * This method must be called after {@link #startSurveillance(Account)} is called.
      *
      * @return True if synchronization is enabled
      */
+    @SuppressWarnings("unused") // SDK implementing apps may check weather sync is disabled completely
     public boolean isSyncEnabled() {
         return ContentResolver.getIsSyncable(currentSynchronizationAccount, authority) == 1;
     }
 
     /**
      * Allows to enable or disable synchronization completely.
+     * <p>
+     * This method must be called after {@link #startSurveillance(Account)} is called. You can also use the
+     * {@link #setSyncEnabled(Account, boolean)} which does not have this requirement.
      *
      * @param enabled True if synchronization should be enabled
      */
+    @SuppressWarnings("unused") // SDK implementing apps may want to disable synchronization completely
     public void setSyncEnabled(final boolean enabled) {
-        ContentResolver.setIsSyncable(currentSynchronizationAccount, authority, enabled ? 1 : 0);
+        setSyncEnabled(currentSynchronizationAccount, enabled);
+    }
+
+    /**
+     * Allows to enable or disable synchronization completely.
+     * <p>
+     * This second interface for setSyncEnabled() with the account parameter is required as
+     * {@code MovebisDataCapturingService#registerJwtAuthToken()} just activate the account before
+     * the account is linked as currentSynchronizationAccount by {@link #startSurveillance(Account)}.
+     *
+     * @param account The {@code Account} to update.
+     * @param enabled True if synchronization should be enabled
+     */
+    public void setSyncEnabled(@NonNull final Account account, final boolean enabled) {
+        ContentResolver.setIsSyncable(account, authority, enabled ? 1 : 0);
     }
 
     public boolean isSyncOnUnMeteredNetworkOnly() {


### PR DESCRIPTION
Die Änderungen hier fixen zum einen
- den Bug den Felix reportet hat - Absturz bei Migration der Datenbank von SDK 2 (db V8) auf SDK 4 (V12). Die Messungen von SDK 2 und Locations bleiben derzeit erhalten, die device id wird neu generiert und die Distanz der alten Messungen wir derzeit noch als 0.0 hinterlegt. Die Änderungen hierfür reiche ich noch nach.
- den Bug den Philipp reportet hat - registerJwtToken schlägt fehl (Warnung in STAD app) weil der Account noch nicht im Survivor verlinkt ist (startSurveillance noch nicht gecalled) und somit NPE. Hier wird nun explizit der Account zum aktivieren mit übergeben wie es vorher der Fall war - mein Fehler. Dafür gibt's einen Test der sichergeht, dass das nicht noch einmal passiert (register Jwt Token darf nicht abstürzen).