### PR TITLE
Extent Multipart header MOV-590

### DIFF
--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
@@ -23,17 +23,20 @@ import androidx.annotation.NonNull;
  */
 final class MockedHttpConnection implements Http {
 
+    @NonNull
     @Override
-    public String returnUrlWithTrailingSlash(String url) {
+    public String returnUrlWithTrailingSlash(@NonNull String url) {
         return url;
     }
 
+    @NonNull
     @Override
     public HttpsURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext,
             boolean hasBinaryContent, @NonNull String jwtBearer) throws ServerUnavailableException {
         return openHttpConnection(url, sslContext, hasBinaryContent);
     }
 
+    @NonNull
     @Override
     public HttpsURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext,
             boolean hasBinaryContent) throws ServerUnavailableException {
@@ -44,15 +47,17 @@ final class MockedHttpConnection implements Http {
         }
     }
 
+    @NonNull
     @Override
-    public HttpResponse post(HttpURLConnection connection, JSONObject payload, boolean compress)
+    public HttpResponse post(@NonNull HttpURLConnection connection, @NonNull JSONObject payload, boolean compress)
             throws ResponseParsingException, UnauthorizedException, BadRequestException {
         return new HttpResponse(201, "");
     }
 
+    @NonNull
     @Override
     public HttpResponse post(@NonNull HttpURLConnection connection, @NonNull File transferTempFile, @NonNull String deviceId,
-                             long measurementId, @NonNull String fileName, UploadProgressListener progressListener)
+                             long measurementId, @NonNull String fileName, @NonNull UploadProgressListener progressListener)
             throws ResponseParsingException, UnauthorizedException, BadRequestException {
         progressListener.updatedProgress(1.0f); // 100%
         return new HttpResponse(201, "");

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
@@ -18,7 +18,7 @@ import androidx.annotation.NonNull;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 3.0.0
  * @since 3.0.0
  */
 final class MockedHttpConnection implements Http {
@@ -56,9 +56,10 @@ final class MockedHttpConnection implements Http {
 
     @NonNull
     @Override
-    public HttpResponse post(@NonNull HttpURLConnection connection, @NonNull File transferTempFile, @NonNull String deviceId,
-                             long measurementId, @NonNull String fileName, @NonNull UploadProgressListener progressListener)
-            throws ResponseParsingException, UnauthorizedException, BadRequestException {
+    public HttpResponse post(@NonNull HttpURLConnection connection, @NonNull File transferTempFile,
+            @NonNull SyncAdapter.MetaData metaData, @NonNull String fileName,
+            @NonNull UploadProgressListener progressListener)
+            throws SynchronisationException, ResponseParsingException, BadRequestException, UnauthorizedException {
         progressListener.updatedProgress(1.0f); // 100%
         return new HttpResponse(201, "");
     }

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import java.io.File;

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/DataTransmissionTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/DataTransmissionTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,9 +30,11 @@ import de.cyface.persistence.DefaultPersistenceBehaviour;
 import de.cyface.persistence.MeasurementContentProviderClient;
 import de.cyface.persistence.NoSuchMeasurementException;
 import de.cyface.persistence.PersistenceLayer;
+import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.PointMetaData;
+import de.cyface.persistence.model.Track;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.persistence.serialization.MeasurementSerializer;
 import de.cyface.persistence.serialization.Point3dFile;
@@ -145,9 +148,19 @@ public class DataTransmissionTest {
             SyncPerformer performer = new SyncPerformer(
                     InstrumentationRegistry.getInstrumentation().getTargetContext());
             SyncResult syncResult = new SyncResult();
+
+            List<Track> tracks = persistence.loadTracks(measurementIdentifier);
+            Validate.isTrue(tracks.size() > 0);
+            GeoLocation startLocation = tracks.get(0).getGeoLocations().get(0);
+            List<GeoLocation> lastTrack = tracks.get(tracks.size() - 1).getGeoLocations();
+            GeoLocation endLocation = lastTrack.get(lastTrack.size() - 1);
+            SyncAdapter.MetaData metaData = new SyncAdapter.MetaData(startLocation, endLocation, "test_did",
+                    measurementIdentifier, "test_deviceType", "test_osVersion", "test_appVersion",
+                    measurement.getDistance(), 2);
+
             try {
                 boolean result = performer.sendData(new HttpConnection(), syncResult, "https://localhost:8080",
-                        measurementIdentifier, "garbage", compressedTransferTempFile, new UploadProgressListener() {
+                        metaData, compressedTransferTempFile, new UploadProgressListener() {
                             @Override
                             public void updatedProgress(float percent) {
                                 Log.d(TAG, String.format("Upload Progress %f", percent));

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/DataTransmissionTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/DataTransmissionTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import static de.cyface.synchronization.TestUtils.AUTHORITY;
@@ -47,7 +61,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.2.2
+ * @version 1.2.3
  * @since 2.0.0
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2017 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import java.io.File;

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -1,7 +1,5 @@
 package de.cyface.synchronization;
 
-import android.accounts.NetworkErrorException;
-
 import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -10,6 +8,8 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 
 import org.json.JSONObject;
+
+import android.accounts.NetworkErrorException;
 
 import androidx.annotation.NonNull;
 
@@ -22,13 +22,15 @@ import androidx.annotation.NonNull;
  * @since 3.0.0
  */
 interface Http {
+
     /**
      * Adds a trailing slash to the server URL or leaves an existing trailing slash untouched.
      *
      * @param url The url to format.
      * @return The server URL with a trailing slash.
      */
-    String returnUrlWithTrailingSlash(String url);
+    @NonNull
+    String returnUrlWithTrailingSlash(@NonNull String url);
 
     /**
      * A HTTPConnection must be opened with the right header before you can communicate with the Cyface REST API
@@ -40,6 +42,7 @@ interface Http {
      * @return the HTTPURLConnection
      * @throws ServerUnavailableException When there seems to be no server at the given URL.
      */
+    @NonNull
     HttpsURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext, boolean hasBinaryContent,
             @NonNull String jwtBearer) throws ServerUnavailableException;
 
@@ -52,6 +55,7 @@ interface Http {
      * @return the HTTPURLConnection
      * @throws ServerUnavailableException When there seems to be no server at the given URL.
      */
+    @NonNull
     HttpsURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext, boolean hasBinaryContent)
             throws ServerUnavailableException;
 
@@ -59,29 +63,39 @@ interface Http {
      * The compressed post request which transmits a measurement batch through an existing http
      * connection
      *
+     * @param connection The {@code HttpURLConnection} to be used for the request.
      * @param payload The measurement batch in json format
-     * @throws DataTransmissionException When the server returned a non-successful status code.
+     * @param compress True if the {@param payload} should get compressed
      * @throws RequestParsingException When the request could not be generated.
-     * @throws ResponseParsingException When the http response could not be parsed.
+     * @throws DataTransmissionException When the server returned a non-successful status code.
      * @throws SynchronisationException When the new data output for the http connection failed to be created.
-     * @throws UnauthorizedException If the credentials for the cyface server are wrong.
+     * @throws ResponseParsingException When the http response could not be parsed.
+     * @throws UnauthorizedException When the server returns {@code HttpURLConnection#HTTP_UNAUTHORIZED}
+     * @throws BadRequestException When server returns {@code HttpURLConnection#HTTP_BAD_REQUEST}
      * @throws NetworkErrorException when the connection's input or error stream was null
      */
-    HttpResponse post(HttpURLConnection connection, JSONObject payload, boolean compress)
-            throws RequestParsingException, DataTransmissionException, SynchronisationException,
+    @NonNull
+    HttpResponse post(@NonNull final HttpURLConnection connection, @NonNull final JSONObject payload,
+            final boolean compress) throws RequestParsingException, DataTransmissionException, SynchronisationException,
             ResponseParsingException, UnauthorizedException, BadRequestException, NetworkErrorException;
 
     /**
      * The serialized post request which transmits a measurement through an existing http connection
      *
-     * @throws ResponseParsingException When the http response could not be parsed.
+     * @param connection The {@code HttpURLConnection} to be used for the request.
+     * @param transferTempFile The data to transmit
+     * @param metaData The {@link SyncAdapter.MetaData} required for the Multipart request.
+     * @param fileName The name of the file to be uploaded
+     * @param progressListener The {@link UploadProgressListener} to be informed about the upload progress.
      * @throws SynchronisationException When the new data output for the http connection failed to be created.
-     * @throws UnauthorizedException If the credentials for the cyface server are wrong.
-     * @throws BadRequestException When the api responses with {@link HttpURLConnection#HTTP_BAD_REQUEST}
+     * @throws ResponseParsingException When the http response could not be parsed.
+     * @throws BadRequestException When server returns {@code HttpURLConnection#HTTP_BAD_REQUEST}
+     * @throws UnauthorizedException When the server returns {@code HttpURLConnection#HTTP_UNAUTHORIZED}
      */
     @SuppressWarnings("UnusedReturnValue") // May be used in the future
-    HttpResponse post(@NonNull HttpURLConnection connection, @NonNull File transferTempFile,
-            @NonNull String deviceId, long measurementId, @NonNull String fileName,
-            UploadProgressListener progressListener)
+    @NonNull
+    HttpResponse post(@NonNull final HttpURLConnection connection, @NonNull final File transferTempFile,
+            @NonNull final SyncAdapter.MetaData metaData, @NonNull final String fileName,
+            @NonNull final UploadProgressListener progressListener)
             throws SynchronisationException, ResponseParsingException, BadRequestException, UnauthorizedException;
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -18,7 +18,7 @@ import androidx.annotation.NonNull;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 3.0.0
+ * @version 4.0.0
  * @since 3.0.0
  */
 interface Http {

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2017 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import static de.cyface.persistence.Constants.DEFAULT_CHARSET;
@@ -37,7 +51,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 3.0.0
+ * @version 4.0.0
  * @since 2.0.0
  */
 public class HttpConnection implements Http {

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpResponse.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpResponse.java
@@ -1,9 +1,11 @@
 package de.cyface.synchronization;
 
+import java.net.HttpURLConnection;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.net.HttpURLConnection;
+import androidx.annotation.NonNull;
 
 /**
  * Internal value object class for the attributes of an HTTP response. It wrappers the HTTP
@@ -15,6 +17,7 @@ import java.net.HttpURLConnection;
  * @since 1.0.0
  */
 class HttpResponse {
+
     private int responseCode;
     private JSONObject body;
 
@@ -25,8 +28,10 @@ class HttpResponse {
      * @param responseBody the HTTP response body returned by the server. Can be null when the login
      *            was successful and there was nothing to return (defined by the Spring API).
      * @throws ResponseParsingException when the server returned something not parsable.
+     * @throws BadRequestException When server returns {@code HttpURLConnection#HTTP_BAD_REQUEST}
+     * @throws UnauthorizedException When the server returns {@code HttpURLConnection#HTTP_UNAUTHORIZED}
      */
-    HttpResponse(final int responseCode, final String responseBody)
+    HttpResponse(final int responseCode, @NonNull final String responseBody)
             throws ResponseParsingException, BadRequestException, UnauthorizedException {
         this.responseCode = responseCode;
         try {
@@ -52,6 +57,7 @@ class HttpResponse {
         }
     }
 
+    @NonNull
     JSONObject getBody() {
         return body;
     }

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpResponse.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpResponse.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2017 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import java.net.HttpURLConnection;
@@ -13,7 +27,7 @@ import androidx.annotation.NonNull;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 1.1.0
+ * @version 2.0.0
  * @since 1.0.0
  */
 class HttpResponse {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2017 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.AUTH_TOKEN_TYPE;
@@ -48,7 +62,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.5.0
+ * @version 2.6.0
  * @since 2.0.0
  */
 public final class SyncAdapter extends AbstractThreadedSyncAdapter {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -327,7 +327,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
      * @version 1.0.0
      * @since 4.0.0
      */
-    class MetaData {
+    static class MetaData {
         final GeoLocation startLocation;
         final GeoLocation endLocation;
         final String deviceId;

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -22,18 +22,23 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SyncResult;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import de.cyface.persistence.DefaultFileAccess;
 import de.cyface.persistence.DefaultPersistenceBehaviour;
 import de.cyface.persistence.MeasurementContentProviderClient;
 import de.cyface.persistence.NoSuchMeasurementException;
 import de.cyface.persistence.PersistenceLayer;
+import de.cyface.persistence.model.GeoLocation;
 import de.cyface.persistence.model.Measurement;
 import de.cyface.persistence.model.MeasurementStatus;
+import de.cyface.persistence.model.Track;
 import de.cyface.persistence.serialization.MeasurementSerializer;
 import de.cyface.utils.CursorIsNullException;
 import de.cyface.utils.Validate;
@@ -155,17 +160,19 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
 
             for (final Measurement measurement : syncableMeasurements) {
 
-                // Load compressed transfer file for measurement
+                // Load measurement with metadata
                 Log.d(Constants.TAG,
                         String.format("Measurement with identifier %d is about to be loaded for transmission.",
                                 measurement.getIdentifier()));
                 final MeasurementContentProviderClient loader = new MeasurementContentProviderClient(
                         measurement.getIdentifier(), provider, authority);
+                final MetaData metaData = loadMetaData(measurement, persistence, deviceId, context);
 
                 // The network setting may have changed since the initial sync call, avoid unnecessary serialization
                 if (isPeriodicSyncDisabled(account, authority)) {
                     return;
                 }
+                // Load compressed transfer file for measurement
                 final File compressedTransferTempFile = serializer.writeSerializedCompressed(loader,
                         measurement.getIdentifier(), persistence);
 
@@ -198,8 +205,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
                             DefaultFileAccess.humanReadableByteCount(compressedTransferTempFile.length(), true)));
                     Validate.notNull(endPointUrl);
                     final boolean transmissionSuccessful = syncPerformer.sendData(http, syncResult, endPointUrl,
-                            measurement.getIdentifier(), deviceId, compressedTransferTempFile,
-                            new UploadProgressListener() {
+                            metaData, compressedTransferTempFile, new UploadProgressListener() {
                                 @Override
                                 public void updatedProgress(float percent) {
                                     for (final ConnectionStatusListener listener : progressListener) {
@@ -246,6 +252,49 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     /**
+     * Loads meta data required in the Multipart header to transfer files to the API.
+     *
+     * @param measurement The {@link Measurement} to load the meta data for
+     * @param persistence The {@link PersistenceLayer} to load track data required
+     * @param deviceId The device identifier generated for this device
+     * @param context The {@code Context} to load the version name of this SDK
+     * @return The {@link MetaData} loaded
+     * @throws CursorIsNullException when accessing the {@code ContentProvider} failed
+     */
+    private MetaData loadMetaData(@NonNull final Measurement measurement,
+            PersistenceLayer<DefaultPersistenceBehaviour> persistence, @NonNull final String deviceId,
+            @NonNull final Context context) throws CursorIsNullException {
+
+        // If there is only one location captured, start and end locations are identical
+        final List<Track> tracks = persistence.loadTracks(measurement.getIdentifier());
+        int locationCount = 0;
+        for (final Track track : tracks) {
+            locationCount += track.getGeoLocations().size();
+        }
+        Validate.isTrue(tracks.size() == 0 || (tracks.get(0).getGeoLocations().size() > 0
+                && tracks.get(tracks.size() - 1).getGeoLocations().size() > 0));
+        final List<GeoLocation> lastTrack = tracks.size() > 0 ? tracks.get(tracks.size() - 1).getGeoLocations() : null;
+        @Nullable
+        final GeoLocation startLocation = tracks.size() > 0 ? tracks.get(0).getGeoLocations().get(0) : null;
+        @Nullable
+        final GeoLocation endLocation = lastTrack != null ? lastTrack.get(lastTrack.size() - 1) : null;
+
+        // Non location meta data
+        final String deviceType = android.os.Build.MODEL;
+        final String osVersion = "Android " + Build.VERSION.RELEASE;
+        final String appVersion;
+        final PackageManager packageManager = context.getPackageManager();
+        try {
+            appVersion = packageManager.getPackageInfo(context.getPackageName(), 0).versionName;
+        } catch (final PackageManager.NameNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+
+        return new MetaData(startLocation, endLocation, deviceId, measurement.getIdentifier(), deviceType, osVersion,
+                appVersion, measurement.getDistance(), locationCount);
+    }
+
+    /**
      * We need to check if the network is still syncable:
      * - this is only possible indirect, we check if the surveyor disabled auto sync for the account
      * - the network settings could have changed between sync initial call and "now"
@@ -269,5 +318,39 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
 
     private void addConnectionListener(final @NonNull ConnectionStatusListener listener) {
         progressListener.add(listener);
+    }
+
+    /**
+     * Meta data which is required in the Multipart header to transfer files to the API.
+     *
+     * @author Armin Schnabel
+     * @version 1.0.0
+     * @since 4.0.0
+     */
+    class MetaData {
+        final GeoLocation startLocation;
+        final GeoLocation endLocation;
+        final String deviceId;
+        final long measurementId;
+        final String deviceType;
+        final String osVersion;
+        final String appVersion;
+        final double length;
+        final int locationCount;
+
+        MetaData(@Nullable final GeoLocation startLocation, @Nullable final GeoLocation endLocation,
+                @NonNull final String deviceId, final long measurementId, @NonNull final String deviceType,
+                @NonNull final String osVersion, @NonNull final String appVersion, final double length,
+                final int locationCount) {
+            this.startLocation = startLocation;
+            this.endLocation = endLocation;
+            this.deviceId = deviceId;
+            this.measurementId = measurementId;
+            this.deviceType = deviceType;
+            this.osVersion = osVersion;
+            this.appVersion = appVersion;
+            this.length = length;
+            this.locationCount = locationCount;
+        }
     }
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2017 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.TAG;
@@ -31,7 +45,7 @@ import androidx.annotation.NonNull;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.1
+ * @version 3.0.0
  * @since 2.0.0
  */
 class SyncPerformer {


### PR DESCRIPTION
Dieser PR fügt die Änderungen im Multipart Header hinzu wie von Philipp erbeten.

Bei der Implementierung habe ich versucht so genau wie möglich der iOS Implementierung zu folgen:
https://github.com/cyface-de/ios-backend/pull/51/files

(Außer den besprochenen Änderungen bei start-/endLocation - Philipp wurde informiert).

_Ist kein großer PR, habe aber wieder ein paar Lizenztexte hinzugefügt welche einige der Lines added ausmachen._