### PR TITLE
Remove validation which should not have been in production code

### DIFF
--- a/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
+++ b/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
@@ -32,6 +32,7 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import de.cyface.testutils.SharedTestUtils;
@@ -102,7 +103,7 @@ public class WifiSurveyorTest {
         Account account = objectUnderTest.createAccount(TestUtils.DEFAULT_USERNAME, null);
 
         // Make sure the new account is in the expected default state
-        WiFiSurveyor.validateAccountFlags(account, AUTHORITY);
+        validateAccountFlags(account);
 
         // Instead of calling startSurveillance as in production we directly call it's implementation
         // Without the networkCallback or networkConnectivity BroadcastReceiver as this would make this test
@@ -110,18 +111,38 @@ public class WifiSurveyorTest {
         objectUnderTest.currentSynchronizationAccount = account;
         objectUnderTest.scheduleSyncNow();
         Thread.sleep(1000); // CI emulator seems to be too slow for less
-        WiFiSurveyor.validateAccountFlags(account, AUTHORITY);
+        validateAccountFlags(account);
         Validate.isTrue(!objectUnderTest.isConnected()); // Ensure default state after startSurveillance
 
         // Act & Assert 1
         objectUnderTest.setConnected(true);
         Thread.sleep(1000); // CI emulator seems to be to slow for less
-        WiFiSurveyor.validateAccountFlags(account, AUTHORITY);
+        validateAccountFlags(account);
         assertThat(objectUnderTest.isConnected(), is(equalTo(true)));
 
         // Act & Assert 2
         objectUnderTest.setConnected(false);
         Thread.sleep(1000); // CI emulator seems to be to slow for less
         assertThat(objectUnderTest.isConnected(), is(equalTo(false)));
+    }
+
+    /**
+     * Makes sure the account flags used by {@link WiFiSurveyor#isConnected()} are valid.
+     * <p>
+     * See {@link WiFiSurveyor#makeAccountSyncable(Account, boolean)} for details.
+     * <p>
+     * <b>Attention:</b> Never use this method in production as the periodicSync flags are set async
+     * by the system so we can never be sure if they are already set or not. For this reason we have the
+     * {@link #testSetConnected()} test.
+     *
+     * @param account The {@code Account} to be checked.
+     */
+    private static void validateAccountFlags(@NonNull final Account account) {
+        final boolean periodicSyncRegistered = ContentResolver.getPeriodicSyncs(account, TestUtils.AUTHORITY)
+                .size() > 0;
+        final boolean autoSyncEnabled = ContentResolver.getSyncAutomatically(account, TestUtils.AUTHORITY);
+        Validate.isTrue(periodicSyncRegistered == autoSyncEnabled,
+                "Both, periodicSync and autoSync, must be in the same state but are: " + periodicSyncRegistered
+                        + " and " + autoSyncEnabled + ", in this order");
     }
 }

--- a/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
+++ b/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
@@ -44,7 +44,7 @@ import de.cyface.utils.Validate;
  * The tests in this class require an emulator or a real device.
  *
  * @author Armin Schnabel
- * @version 1.0.1
+ * @version 1.0.2
  * @since 4.0.0
  */
 @RunWith(AndroidJUnit4.class)

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -44,7 +44,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.0.0
+ * @version 7.0.1
  * @since 2.0.0
  */
 public class WiFiSurveyor extends BroadcastReceiver {

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -336,22 +336,7 @@ public class WiFiSurveyor extends BroadcastReceiver {
         ContentResolver.setSyncAutomatically(account, authority, false);
         setSyncEnabled(account, enabled);
 
-        validateAccountFlags(account, authority);
-    }
-
-    /**
-     * Makes sure the account flags used by {@link #isConnected()} are valid.
-     * <p>
-     * See {@link #makeAccountSyncable(Account, boolean)} for details.
-     *
-     * @param account The {@code Account} to be checked.
-     */
-    public static void validateAccountFlags(@NonNull final Account account, @NonNull final String authority) {
-        final boolean periodicSyncRegistered = ContentResolver.getPeriodicSyncs(account, authority).size() > 0;
-        final boolean autoSyncEnabled = ContentResolver.getSyncAutomatically(account, authority);
-        Validate.isTrue(periodicSyncRegistered == autoSyncEnabled,
-                "Both, periodicSync and autoSync, must be in the same state but are: " + periodicSyncRegistered
-                        + " and " + autoSyncEnabled + ", in this order");
+            // Do not use validateAccountFlags in production code as periodicSync flags are set async
     }
 
     /**


### PR DESCRIPTION
The ValidationException thrown could be the cause that the synchronization does not start on the STAD app so I release this as fix until I can reproduce the bug locally.