### PR TITLE
Fix 4.0.0 alpha6/mov 654 multi part header wrongly assembled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.2.10
+ * @version 2.2.11
  * @since 1.0.0
  */
 
@@ -32,7 +32,7 @@ buildscript {
 
 ext {
     groupId = 'de.cyface'
-    version = "4.0.0-alpha4"
+    version = "4.0.0-alpha6"
 
     minSdkVersion = 16
     targetSdkVersion = 28

--- a/datacapturing/src/test/java/de/cyface/datacapturing/backend/CapturingProcessTest.java
+++ b/datacapturing/src/test/java/de/cyface/datacapturing/backend/CapturingProcessTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2017 Cyface GmbH
+ * This file is part of the Cyface SDK for Android.
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
 package de.cyface.datacapturing.backend;
 
 import static org.junit.Assert.assertThat;
@@ -25,6 +39,7 @@ import android.hardware.SensorManager;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.HandlerThread;
+
 import androidx.annotation.NonNull;
 import de.cyface.datacapturing.model.CapturedData;
 import de.cyface.persistence.model.GeoLocation;
@@ -34,7 +49,7 @@ import de.cyface.utils.Validate;
  * Test cases to test the correct working of the data capturing process.
  *
  * @author Klemens Muthmann
- * @version 1.0.1
+ * @version 1.0.2
  * @since 2.0.0
  */
 public class CapturingProcessTest {
@@ -61,7 +76,7 @@ public class CapturingProcessTest {
     @Mock
     private HandlerThread geoLocationEventHandlerThread;
     /**
-     * A mock for the thread handling the occurrnce of new sensor values.
+     * A mock for the thread handling the occurrence of new sensor values.
      */
     @Mock
     private HandlerThread sensorEventHandlerThread;
@@ -89,7 +104,7 @@ public class CapturingProcessTest {
                 }, geoLocationEventHandlerThread, sensorEventHandlerThread);
         testListener = new TestCapturingProcessListener();
         oocut.addCapturingProcessListener(testListener);
-        final Sensor accelerometer = initSensor(Sensor.TYPE_ACCELEROMETER, "accelerometer");
+        final Sensor accelerometer = initSensor("accelerometer");
         when(sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)).thenReturn(accelerometer);
     }
 
@@ -157,16 +172,17 @@ public class CapturingProcessTest {
     /**
      * Initializes a sensor with the provided type and name.
      *
-     * @param sensorType The type of the sensor usually given as a static variable.
      * @param name The name of the sensor
      * @return The newly initialized <code>Sensor</code>.
      */
-    private Sensor initSensor(final int sensorType, final @NonNull String name) {
+    @SuppressWarnings("SameParameterValue") // we probably want to implement this for other sensors too
+    @NonNull
+    private Sensor initSensor(@NonNull final String name) {
         Validate.notEmpty(name);
 
         Sensor sensor = Mockito.mock(Sensor.class);
         when(sensor.getName()).thenReturn(name);
-        when(sensor.getVendor()).thenReturn("Cyfac");
+        when(sensor.getVendor()).thenReturn("Cyface");
         return sensor;
     }
 

--- a/datacapturing/src/test/java/de/cyface/datacapturing/backend/CapturingProcessTest.java
+++ b/datacapturing/src/test/java/de/cyface/datacapturing/backend/CapturingProcessTest.java
@@ -38,6 +38,7 @@ import de.cyface.utils.Validate;
  * @since 2.0.0
  */
 public class CapturingProcessTest {
+
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
     /**

--- a/synchronization/build.gradle
+++ b/synchronization/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$rootProject.ext.rulesVersion"
 
     // Dependencies for local unit tests
+    testImplementation project(":testutils")
     // - If Junit symbols are not resolvable in IntelliJ, make sure Build Variant is set to debug
     // - Loading another dependency (e.g. module) only it's production dependencies (compile) are loaded but not other dependencies (e.g. testCompile)
     testImplementation "junit:junit:$rootProject.ext.junitVersion"

--- a/synchronization/build.gradle
+++ b/synchronization/build.gradle
@@ -6,7 +6,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.1.3
+ * @version 2.1.4
  * @since 1.0.0
  */
 

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -313,8 +313,8 @@ public class HttpConnection implements Http {
         final String lengthPart = generatePart("length", String.valueOf(metaData.length));
 
         // This was reordered to be in the same order as in the iOS code
-        return fileHeaderPart + startLocationPart + endLocationPart + deviceIdPart + measurementIdPart + deviceTypePart
-                + osVersionPart + appVersionPart + lengthPart + locationCountPart;
+        return startLocationPart + endLocationPart + deviceIdPart + measurementIdPart + deviceTypePart
+                + osVersionPart + appVersionPart + lengthPart + locationCountPart + fileHeaderPart;
     }
 
     /**

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -67,7 +67,7 @@ public class HttpConnection implements Http {
     /**
      * The tail to be used in the Multipart request to indicate that the request end.
      */
-    private final static String TAIL = "\r\n--" + BOUNDARY + "--\r\n";
+    final static String TAIL = "\r\n--" + BOUNDARY + "--\r\n";
 
     @NonNull
     @Override
@@ -281,8 +281,8 @@ public class HttpConnection implements Http {
      * @return The Multipart header
      */
     @NonNull
-    private String generateHeader(final long filePartSize, @NonNull final SyncAdapter.MetaData metaData,
-            @NonNull final String fileName) {
+    String generateHeader(final long filePartSize, @NonNull final SyncAdapter.MetaData metaData,
+                          @NonNull final String fileName) {
 
         // File meta data
         final String filePart = "--" + BOUNDARY + "\r\n"

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -51,7 +51,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.0
+ * @version 4.0.1
  * @since 2.0.0
  */
 public class HttpConnection implements Http {
@@ -282,7 +282,7 @@ public class HttpConnection implements Http {
      */
     @NonNull
     String generateHeader(final long filePartSize, @NonNull final SyncAdapter.MetaData metaData,
-                          @NonNull final String fileName) {
+            @NonNull final String fileName) {
 
         // File meta data
         final String filePart = "--" + BOUNDARY + "\r\n"
@@ -313,8 +313,8 @@ public class HttpConnection implements Http {
         final String lengthPart = generatePart("length", String.valueOf(metaData.length));
 
         // This was reordered to be in the same order as in the iOS code
-        return startLocationPart + endLocationPart + deviceIdPart + measurementIdPart + deviceTypePart
-                + osVersionPart + appVersionPart + lengthPart + locationCountPart + fileHeaderPart;
+        return startLocationPart + endLocationPart + deviceIdPart + measurementIdPart + deviceTypePart + osVersionPart
+                + appVersionPart + lengthPart + locationCountPart + fileHeaderPart;
     }
 
     /**

--- a/synchronization/src/test/java/de/cyface/synchronization/HttpConnectionTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/HttpConnectionTest.java
@@ -1,0 +1,78 @@
+package de.cyface.synchronization;
+
+import static de.cyface.synchronization.HttpConnection.TAIL;
+import static de.cyface.testutils.SharedTestUtils.generateGeoLocation;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.cyface.persistence.model.GeoLocation;
+import de.cyface.utils.Validate;
+
+/**
+ * Tests whether our default implementation of the {@link Http} protocol works as expected.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.0
+ */
+public class HttpConnectionTest {
+
+    private HttpConnection oocut;
+
+    /**
+     * Initializes all required properties and adds the <code>testListener</code> to the <code>CapturingProcess</code>.
+     */
+    @Before
+    public void setUp() {
+        oocut = new HttpConnection();
+    }
+
+    /**
+     * Tests that the MultiPart header is generated correctly.
+     * <p>
+     * This test reproduced MOV-655 where the header parts were assembled in the wrong order. As a consequence
+     * the file binary which is added directly at the end of the header was added to the locationCount header part
+     * instead of the file header part which was the last part of the header before.
+     */
+    @Test
+    public void testGenerateHeader() {
+
+        // Arrange
+        final byte[] testFile = "TEST_FILE_CONTENT".getBytes();
+        final long filePartSize = testFile.length + TAIL.length();
+        Validate.isTrue(filePartSize > TAIL.length());
+        final GeoLocation startLocation = generateGeoLocation(0);
+        final GeoLocation endLocation = generateGeoLocation(10);
+        final SyncAdapter.MetaData metaData = new SyncAdapter.MetaData(startLocation, endLocation, "test-did", 78,
+                "test_deviceType", "test_osVersion", "test_appVersion", 10.0, 5);
+
+        // Act
+        final String header = oocut.generateHeader(filePartSize, metaData, "test-did_78");
+
+        // Assert
+        final String expectedHeader = "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"startLocation\"\r\n" + "\r\n"
+                + "51.1, 13.1, 1000000000\r\n" + "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"endLocation\"\r\n" + "\r\n"
+                + "51.10008993199995, 13.100000270697, 1000010000\r\n" + "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"deviceId\"\r\n" + "\r\n" + "test-did\r\n"
+                + "-----------------------------boundary\r\n" + "Content-Disposition: form-data; name=\"measurementId\"\r\n"
+                + "\r\n" + "78\r\n" + "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"deviceType\"\r\n" + "\r\n" + "test_deviceType\r\n"
+                + "-----------------------------boundary\r\n" + "Content-Disposition: form-data; name=\"osVersion\"\r\n"
+                + "\r\n" + "test_osVersion\r\n" + "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"appVersion\"\r\n" + "\r\n" + "test_appVersion\r\n"
+                + "-----------------------------boundary\r\n" + "Content-Disposition: form-data; name=\"length\"\r\n" + "\r\n"
+                + "10.0\r\n" + "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"locationCount\"\r\n" + "\r\n" + "5\r\n"
+                + "-----------------------------boundary\r\n"
+                + "Content-Disposition: form-data; name=\"fileToUpload\"; filename=\"test-did_78.cyf\"\r\n"
+                + "Content-Type: application/octet-stream\r\n" + "Content-Transfer-Encoding: binary\r\n"
+                + "Content-length: 60\r\n" + "\r\n";
+        assertThat(header, is(equalTo(expectedHeader)));
+    }
+}

--- a/synchronization/src/test/java/de/cyface/synchronization/HttpConnectionTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/HttpConnectionTest.java
@@ -51,7 +51,7 @@ public class HttpConnectionTest {
                 "test_deviceType", "test_osVersion", "test_appVersion", 10.0, 5);
 
         // Act
-        final String header = oocut.generateHeader(filePartSize, metaData, "test-did_78");
+        final String header = oocut.generateHeader(filePartSize, metaData, "test-did_78.cyf");
 
         // Assert
         final String expectedHeader = "-----------------------------boundary\r\n"


### PR DESCRIPTION
Hier ist ein Fix für den Fehler im aktuellen dev Release bei dem die Daten mit in den locationCount MultiPart Header Part geschrieben werden. Ich habe einen Failing Test erstellt um sicherzugehen, dass der Header nicht noch einmal versehentlich falsch formatiert wird.