### PR TITLE
Bug/mov 527 data capturing service tests flaky

### DIFF
--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/TestStartUpFinishedHandler.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/TestStartUpFinishedHandler.java
@@ -15,6 +15,7 @@ import androidx.annotation.NonNull;
  * @since 2.2.0
  */
 final class TestStartUpFinishedHandler extends StartUpFinishedHandler {
+
     /**
      * The last measurement identifier received by this handler. If you reuse this handler for multiple times this value
      * is overwritten by the last call. If the handler was never called its value is -1.
@@ -34,11 +35,13 @@ final class TestStartUpFinishedHandler extends StartUpFinishedHandler {
      *
      * @param lock The lock used to synchronize this handler with the calling test.
      * @param condition The condition used to synchronize this handler with the calling test.
-     * @param deviceId The device id used to generate unique global broadcast ids.
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
     TestStartUpFinishedHandler(final @NonNull Lock lock, final @NonNull Condition condition,
-            @NonNull final String deviceId) {
-        super(deviceId);
+            @NonNull final String appId) {
+        super(appId);
         this.lock = lock;
         this.condition = condition;
     }

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/BackgroundServiceTest.java
@@ -168,7 +168,7 @@ public class BackgroundServiceTest {
         // This must not run on the main thread or it will produce an ANR.
         lock.lock();
         try {
-            if (!testCallback.isRunning) {
+            if (!testCallback.wasRunning()) {
                 if (!condition.await(2, TimeUnit.MINUTES)) {
                     throw new IllegalStateException("Waiting for pong or timeout timed out!");
                 }
@@ -182,9 +182,9 @@ public class BackgroundServiceTest {
         // Unbind background service
         serviceTestRule.unbindService();
 
-        assertThat("It seems that service did not respond to a ping.", testCallback.isRunning, is(equalTo(true)));
-        assertThat("It seems that the request to the service whether it was active timed out.", testCallback.timedOut,
-                is(equalTo(false)));
+        assertThat("It seems that service did not respond to a ping.", testCallback.wasRunning(), is(equalTo(true)));
+        assertThat("It seems that the request to the service whether it was active timed out.",
+                testCallback.didTimeOut(), is(equalTo(false)));
     }
 
     /**
@@ -223,7 +223,7 @@ public class BackgroundServiceTest {
         // This must not run on the main thread or it will produce an ANR.
         lock.lock();
         try {
-            if (!testCallback.isRunning) {
+            if (!testCallback.wasRunning()) {
                 if (!condition.await(2, TimeUnit.MINUTES)) {
                     throw new IllegalStateException("Waiting for pong or timeout timed out!");
                 }
@@ -234,8 +234,8 @@ public class BackgroundServiceTest {
             lock.unlock();
         }
 
-        assertThat("It seems that service did not respond to a ping.", testCallback.isRunning, is(equalTo(true)));
-        assertThat("It seems that the request to the service whether it was active timed out.", testCallback.timedOut,
-                is(equalTo(false)));
+        assertThat("It seems that service did not respond to a ping.", testCallback.wasRunning(), is(equalTo(true)));
+        assertThat("It seems that the request to the service whether it was active timed out.",
+                testCallback.didTimeOut(), is(equalTo(false)));
     }
 }

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/TestCallback.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/TestCallback.java
@@ -1,14 +1,14 @@
 package de.cyface.datacapturing.backend;
 
-import androidx.annotation.NonNull;
-import android.util.Log;
+import static de.cyface.datacapturing.TestUtils.TAG;
 
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
-import de.cyface.datacapturing.IsRunningCallback;
+import android.util.Log;
 
-import static de.cyface.datacapturing.TestUtils.TAG;
+import androidx.annotation.NonNull;
+import de.cyface.datacapturing.IsRunningCallback;
 
 /**
  * A callback used to check whether the service has successfully started or not.
@@ -22,14 +22,15 @@ import static de.cyface.datacapturing.TestUtils.TAG;
  * @version 3.1.0
  */
 public class TestCallback implements IsRunningCallback {
+
     /**
      * Flag indicating a successful startup if <code>true</code>.
      */
-    public boolean isRunning = false;
+    private boolean isRunning = false;
     /**
      * Flag indicating an unsuccessful startup if <code>true</code>.
      */
-    public boolean timedOut = false;
+    private boolean timedOut = false;
     /**
      * <code>Lock</code> used to synchronize the callback with the test case using it.
      */
@@ -38,19 +39,19 @@ public class TestCallback implements IsRunningCallback {
      * <code>Condition</code> used to signal the test case to continue processing.
      */
     private final Condition condition;
-
     /**
      * A tag used to mark messages from different instances of this class.
      */
     private final String logTag;
 
     /**
-     * Creates a new completely intialized <code>TestCallback</code>
+     * Creates a new completely initialized <code>TestCallback</code>
      *
      * @param logTag A tag used to mark messages from different instances of this class.
      * @param lock <code>Lock</code> used to synchronize the callback with the test case using it.
      * @param condition <code>Condition</code> used to signal the test case to continue processing.
      */
+    @SuppressWarnings("WeakerAccess") // DataCapturingServiceTest in the Cyface flavour requires this
     public TestCallback(final @NonNull String logTag, final @NonNull Lock lock, final @NonNull Condition condition) {
         this.logTag = logTag;
         this.lock = lock;
@@ -93,6 +94,7 @@ public class TestCallback implements IsRunningCallback {
      * @return A value of <code>true</code> if the service reported that it is running; <code>false</code> if it times
      *         out.
      */
+    @SuppressWarnings("WeakerAccess") // DataCapturingServiceTest in the Cyface flavour requires this
     public boolean wasRunning() {
         return isRunning;
     }
@@ -102,6 +104,7 @@ public class TestCallback implements IsRunningCallback {
      *         This usually means the service is not running at the moment. Return <code>false</code> if a message has
      *         been received.
      */
+    @SuppressWarnings("WeakerAccess") // DataCapturingServiceTest in the Cyface flavour requires this
     public boolean didTimeOut() {
         return timedOut;
     }

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/ToServiceConnection.java
@@ -26,6 +26,7 @@ import de.cyface.datacapturing.PongReceiver;
  * @since 2.0.0
  */
 class ToServiceConnection implements ServiceConnection {
+
     /**
      * The context this <code>ServiceConnection</code> runs with.
      */
@@ -35,24 +36,29 @@ class ToServiceConnection implements ServiceConnection {
      */
     TestCallback callback;
     /**
-     * The <code>Messenger</code> handling messages comming from the <code>DataCapturingBackgroundService</code>.
+     * The <code>Messenger</code> handling messages coming from the <code>DataCapturingBackgroundService</code>.
      */
     private Messenger fromServiceMessenger;
     /**
-     * The device id used to generate an unique broadcast id
+     * A device-wide unique identifier for the application containing this SDK such as
+     * {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     * <p>
+     * <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    private final String deviceId;
+    private final String appId;
 
     /**
      * Creates a new completely initialized <code>ToServiceConnection</code>.
      *
-     * @param fromServiceMessenger The <code>Messenger</code> handling messages comming from the
+     * @param fromServiceMessenger The <code>Messenger</code> handling messages coming from the
      *            <code>DataCapturingBackgroundService</code>.
-     * @param deviceId The device id used to generate an unique broadcast id
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    ToServiceConnection(final @NonNull Messenger fromServiceMessenger, @NonNull final String deviceId) {
+    ToServiceConnection(@NonNull final Messenger fromServiceMessenger, @NonNull final String appId) {
         this.fromServiceMessenger = fromServiceMessenger;
-        this.deviceId = deviceId;
+        this.appId = appId;
     }
 
     @Override
@@ -71,7 +77,7 @@ class ToServiceConnection implements ServiceConnection {
             throw new IllegalStateException(e);
         }
 
-        PongReceiver isRunningChecker = new PongReceiver(context, deviceId);
+        PongReceiver isRunningChecker = new PongReceiver(context, appId);
         isRunningChecker.checkIsRunningAsync(1, TimeUnit.MINUTES, callback);
     }
 

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -205,7 +205,7 @@ public class DataCapturingServiceTest {
         TestUtils.callCheckForRunning(oocut, runningStatusCallback);
         TestUtils.lockAndWait(2, TimeUnit.SECONDS, lock, condition);
 
-        return runningStatusCallback.wasRunning() && !runningStatusCallback.timedOut;
+        return runningStatusCallback.wasRunning() && !runningStatusCallback.didTimeOut();
     }
 
     /**

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -119,6 +119,13 @@ public class DataCapturingServiceTest {
      * {@link PersistenceLayer} required to access stored {@link Measurement}s.
      */
     private PersistenceLayer<DefaultPersistenceBehaviour> persistenceLayer;
+    /**
+     * A device-wide unique identifier for the application containing this SDK such as
+     * {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     * <p>
+     * <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
+     */
+    private String appId;
 
     /**
      * Initializes the super class as well as the object of the class under test and the synchronization lock. This is
@@ -156,6 +163,7 @@ public class DataCapturingServiceTest {
                 new DefaultPersistenceBehaviour());
         // A listener catching messages send to the UI in real applications.
         runningStatusCallback = new TestCallback("Default Callback", lock, condition);
+        appId = context.getPackageName();
 
         // Making sure there is no service instance of a previous test running
         Validate.isTrue(!isDataCapturingServiceRunning());
@@ -223,7 +231,7 @@ public class DataCapturingServiceTest {
             CursorIsNullException, CorruptedMeasurementException {
 
         final TestStartUpFinishedHandler startUpFinishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         oocut.start(Vehicle.UNKNOWN, startUpFinishedHandler);
 
         return checkThatLaunched(startUpFinishedHandler);
@@ -268,7 +276,7 @@ public class DataCapturingServiceTest {
             DataCapturingException, CursorIsNullException, NoSuchMeasurementException {
 
         final TestStartUpFinishedHandler startUpFinishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         oocut.resume(startUpFinishedHandler);
 
         final long resumedMeasurementId = checkThatLaunched(startUpFinishedHandler);
@@ -390,11 +398,11 @@ public class DataCapturingServiceTest {
     public void testMultipleStartStopWithoutDelay() throws DataCapturingException, MissingPermissionException,
             NoSuchMeasurementException, CursorIsNullException, CorruptedMeasurementException {
         final TestStartUpFinishedHandler startUpFinishedHandler1 = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         final TestStartUpFinishedHandler startUpFinishedHandler2 = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         final TestStartUpFinishedHandler startUpFinishedHandler3 = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         final TestShutdownFinishedHandler shutDownFinishedHandler1 = new TestShutdownFinishedHandler(lock, condition);
         final TestShutdownFinishedHandler shutDownFinishedHandler2 = new TestShutdownFinishedHandler(lock, condition);
         final TestShutdownFinishedHandler shutDownFinishedHandler3 = new TestShutdownFinishedHandler(lock, condition);
@@ -472,7 +480,7 @@ public class DataCapturingServiceTest {
 
         // Second start - should not launch anything
         final TestStartUpFinishedHandler startUpFinishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         oocut.start(Vehicle.UNKNOWN, startUpFinishedHandler);
         TestUtils.lockAndWait(2, TimeUnit.SECONDS, lock, condition);
         assertThat(startUpFinishedHandler.receivedServiceStarted(), is(equalTo(false)));
@@ -632,7 +640,7 @@ public class DataCapturingServiceTest {
         PersistenceLayer<CapturingPersistenceBehaviour> persistence = new PersistenceLayer<>(context,
                 context.getContentResolver(), AUTHORITY, new CapturingPersistenceBehaviour());
         final TestStartUpFinishedHandler startUpFinishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                appId);
         oocut.resume(startUpFinishedHandler);
         TestUtils.callCheckForRunning(oocut, runningStatusCallback);
         TestUtils.lockAndWait(2, TimeUnit.SECONDS, lock, condition);

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTestWithoutPermission.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTestWithoutPermission.java
@@ -58,13 +58,17 @@ public class DataCapturingServiceTestWithoutPermission {
      * Condition waiting for the background service to wake up this test case.
      */
     private Condition condition;
+    /**
+     * The {@link Context} needed to access the persistence layer
+     */
+    private Context context;
 
     /**
      * Initializes the object of class under test.
      */
     @Before
     public void setUp() {
-        final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final ContentResolver contentResolver = context.getContentResolver();
 
         // The LOGIN_ACTIVITY is normally set to the LoginActivity of the SDK implementing app
@@ -99,7 +103,7 @@ public class DataCapturingServiceTestWithoutPermission {
     public void testServiceDoesNotStartWithoutPermission() throws MissingPermissionException, DataCapturingException,
             CursorIsNullException, CorruptedMeasurementException {
         final TestStartUpFinishedHandler startUpFinishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                oocut.getDeviceIdentifier());
+                context.getPackageName());
         oocut.start(Vehicle.UNKNOWN, startUpFinishedHandler);
         // if the test fails we might need to wait a bit as we're async
     }
@@ -116,7 +120,7 @@ public class DataCapturingServiceTestWithoutPermission {
         boolean exceptionCaught = false;
         try {
             final TestStartUpFinishedHandler startUpFinishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                    oocut.getDeviceIdentifier());
+                    context.getPackageName());
             oocut.start(Vehicle.UNKNOWN, startUpFinishedHandler);
         } catch (DataCapturingException | MissingPermissionException e) {
             assertThat(uiListener.requiredPermission, is(equalTo(true)));

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/PingPongTest.java
@@ -1,6 +1,7 @@
 package de.cyface.datacapturing;
 
 import static de.cyface.datacapturing.TestUtils.AUTHORITY;
+import static de.cyface.testutils.SharedTestUtils.clearPersistenceLayer;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -10,6 +11,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,27 +25,25 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
+import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
 import de.cyface.datacapturing.backend.TestCallback;
 import de.cyface.datacapturing.exception.CorruptedMeasurementException;
 import de.cyface.datacapturing.exception.DataCapturingException;
 import de.cyface.datacapturing.exception.MissingPermissionException;
 import de.cyface.datacapturing.exception.SetupException;
-import de.cyface.persistence.DefaultPersistenceBehaviour;
-import de.cyface.persistence.NoDeviceIdException;
 import de.cyface.persistence.NoSuchMeasurementException;
-import de.cyface.persistence.PersistenceLayer;
 import de.cyface.persistence.model.Vehicle;
 import de.cyface.synchronization.CyfaceAuthenticator;
 import de.cyface.utils.CursorIsNullException;
 
 /**
- * This test checks that the ping pong mechanism, which is used to check if a service is running or not, works as
- * expected.
+ * This test checks that the ping pong mechanism works as expected. This mechanism ist used to check if a service, in
+ * this case the {@link DataCapturingBackgroundService}, is running or not.
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
  * @version 1.2.2
- * @since 2.3.2
+ * @since 2.3.
  */
 @RunWith(AndroidJUnit4.class)
 @MediumTest
@@ -52,15 +52,13 @@ public class PingPongTest {
     /**
      * The time to wait for the pong message to return and for the service to start or stop.
      */
-    private static final long TIMEOUT_TIME = 10L;
-
+    public static final long TIMEOUT_TIME = 1L; // FIXME
     /**
      * Grants the permission required by the {@link DataCapturingService}.
      */
     @Rule
     public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule
             .grant(android.Manifest.permission.ACCESS_FINE_LOCATION);
-
     /**
      * An instance of the class under test (object of class under test).
      */
@@ -77,25 +75,27 @@ public class PingPongTest {
      * The {@link DataCapturingService} instance used by the test to check whether a pong can be received.
      */
     private DataCapturingService dcs;
+    /**
+     * The {@link Context} required to send unique broadcasts and to start the capturing service.
+     */
+    private Context context;
 
     /**
      * Sets up all the instances required by all tests in this test class.
      *
-     * @throws CursorIsNullException Then the content provider is not accessible
-     * @throws NoDeviceIdException When the device id is not set
      */
     @Before
-    public void setUp() throws CursorIsNullException, NoDeviceIdException {
+    public void setUp() {
         lock = new ReentrantLock();
         condition = lock.newCondition();
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        // This is normally called in the <code>DataCapturingService#Constructor</code>
-        PersistenceLayer<DefaultPersistenceBehaviour> persistence = new PersistenceLayer<>(context,
-                context.getContentResolver(), AUTHORITY, new DefaultPersistenceBehaviour());
-        persistence.restoreOrCreateDeviceId();
+        oocut = new PongReceiver(context, context.getPackageName());
+    }
 
-        oocut = new PongReceiver(context, persistence.loadDeviceId());
+    @After
+    public void tearDown() {
+        clearPersistenceLayer(context, context.getContentResolver(), AUTHORITY);
     }
 
     /**
@@ -111,28 +111,29 @@ public class PingPongTest {
     public void testWithRunningService() throws MissingPermissionException, DataCapturingException,
             NoSuchMeasurementException, CursorIsNullException, CorruptedMeasurementException {
 
+        // Arrange
+        // Instantiate DataCapturingService
+        final DataCapturingListener testListener = new TestListener(lock, condition);
         // The LOGIN_ACTIVITY is normally set to the LoginActivity of the SDK implementing app
         CyfaceAuthenticator.LOGIN_ACTIVITY = AccountAuthenticatorActivity.class;
-
-        final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
-        final DataCapturingListener listener = new TestListener(lock, condition);
         InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
                 try {
                     dcs = new CyfaceDataCapturingService(context, context.getContentResolver(), TestUtils.AUTHORITY,
-                            TestUtils.ACCOUNT_TYPE, "https://fake.fake/", new IgnoreEventsStrategy(), listener);
+                            TestUtils.ACCOUNT_TYPE, "https://fake.fake/", new IgnoreEventsStrategy(), testListener);
                 } catch (SetupException | CursorIsNullException e) {
                     throw new IllegalStateException(e);
                 }
             }
         });
-        StartUpFinishedHandler finishedHandler = new TestStartUpFinishedHandler(lock, condition,
-                dcs.getDeviceIdentifier());
 
+        // Start Capturing
+        StartUpFinishedHandler finishedHandler = new TestStartUpFinishedHandler(lock, condition,
+                context.getPackageName());
         dcs.start(Vehicle.UNKNOWN, finishedHandler);
 
+        // Give the async start some time to start the DataCapturingBackgroundService
         lock.lock();
         try {
             condition.await(TIMEOUT_TIME, TimeUnit.SECONDS);
@@ -142,9 +143,12 @@ public class PingPongTest {
             lock.unlock();
         }
 
+        // Act
+        // Check if DataCapturingBackgroundService is running
         TestCallback testCallback = new TestCallback("testWithRunningService", lock, condition);
         oocut.checkIsRunningAsync(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
 
+        // Give the async call some time
         lock.lock();
         try {
             condition.await(2 * TIMEOUT_TIME, TimeUnit.SECONDS);
@@ -154,12 +158,17 @@ public class PingPongTest {
             lock.unlock();
         }
 
+        // Assert
+        // Ensure DataCapturingBackgroundService was running during the async check
         assertThat(testCallback.wasRunning(), is(equalTo(true)));
         assertThat(testCallback.didTimeOut(), is(equalTo(false)));
 
+        // Cleanup
+        // Stop Capturing
         TestShutdownFinishedHandler shutdownHandler = new TestShutdownFinishedHandler(lock, condition);
         dcs.stop(shutdownHandler);
 
+        // Give the async stop some time to stop gracefully
         lock.lock();
         try {
             condition.await(TIMEOUT_TIME, TimeUnit.SECONDS);
@@ -175,10 +184,13 @@ public class PingPongTest {
      */
     @Test
     public void testWithNonRunningService() {
-        TestCallback testCallback = new TestCallback("testWithNonRunningService", lock, condition);
 
+        // Act
+        // Check if DataCapturingBackgroundService is running
+        TestCallback testCallback = new TestCallback("testWithNonRunningService", lock, condition);
         oocut.checkIsRunningAsync(TIMEOUT_TIME, TimeUnit.SECONDS, testCallback);
 
+        // Give the async call some time
         lock.lock();
         try {
             condition.await(2 * TIMEOUT_TIME, TimeUnit.SECONDS);
@@ -188,6 +200,8 @@ public class PingPongTest {
             lock.unlock();
         }
 
+        // Assert
+        // Ensure DataCapturingBackgroundService was running during the async check
         assertThat(testCallback.didTimeOut(), is(equalTo(true)));
         assertThat(testCallback.wasRunning(), is(equalTo(false)));
     }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/Constants.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/Constants.java
@@ -18,7 +18,7 @@ public final class Constants {
     /**
      * Tas used for logging from {@link DataCapturingBackgroundService}
      */
-    public final static String BACKGROUND_TAG = "de.cyface.background";
+    public final static String BACKGROUND_TAG = "de.cyface.capturing.bgs";
     /**
      * The minimum space required for capturing. We don't want to use the space full up as this would
      * slow down the device and could get unusable.

--- a/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/MessageCodes.java
@@ -1,5 +1,6 @@
 package de.cyface.datacapturing;
 
+import androidx.annotation.NonNull;
 import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
 
 /**
@@ -12,6 +13,7 @@ import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
  * @since 2.0.0
  */
 public class MessageCodes {
+
     /**
      * The code for messages sent from the {@link DataCapturingService} to the
      * {@link de.cyface.datacapturing.backend.DataCapturingBackgroundService} to register the former as client of the
@@ -55,7 +57,6 @@ public class MessageCodes {
      * when it notices that only little space is left.
      */
     public static final int SERVICE_STOPPED_ITSELF = 11;
-
     /**
      * Global Broadcast (inter-process) action identifier for service started messages sent by the
      * {@link DataCapturingBackgroundService} to the {@link DataCapturingService}.
@@ -77,30 +78,39 @@ public class MessageCodes {
      * To avoid collision between sdk integrating apps use the app unique device id as prefix when using
      * this a action identifier for global broadcasts (for inter process communication)
      * 
-     * @param deviceId The device id used to make global broadcast ids unique
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    public static String getServiceStartedActionId(final String deviceId) {
-        return deviceId + "_" + GLOBAL_BROADCAST_SERVICE_STARTED;
+    @NonNull
+    public static String getServiceStartedActionId(@NonNull final String appId) {
+        return appId + "_" + GLOBAL_BROADCAST_SERVICE_STARTED;
     }
 
     /**
      * To avoid collision between sdk integrating apps use the app unique device id as prefix when using
      * this a action identifier for global broadcasts (for inter process communication)
      *
-     * @param deviceId The device id used to make global broadcast ids unique
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    public static String getPingActionId(final String deviceId) {
-        return deviceId + "_" + GLOBAL_BROADCAST_PING;
+    @NonNull
+    public static String getPingActionId(@NonNull final String appId) {
+        return appId + "_" + GLOBAL_BROADCAST_PING;
     }
 
     /**
      * To avoid collision between sdk integrating apps use the app unique device id as prefix when using
      * this a action identifier for global broadcasts (for inter process communication)
      *
-     * @param deviceId The device id used to make global broadcast ids unique
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    public static String getPongActionId(final String deviceId) {
-        return deviceId + "_" + GLOBAL_BROADCAST_PONG;
+    @NonNull
+    public static String getPongActionId(@NonNull final String appId) {
+        return appId + "_" + GLOBAL_BROADCAST_PONG;
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -1,7 +1,5 @@
 package de.cyface.datacapturing;
 
-import static de.cyface.datacapturing.Constants.TAG;
-
 import java.lang.ref.WeakReference;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -21,6 +19,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
+import de.cyface.datacapturing.backend.PingReceiver;
 import de.cyface.synchronization.BundlesExtrasCodes;
 
 /**
@@ -35,6 +34,11 @@ import de.cyface.synchronization.BundlesExtrasCodes;
  */
 public class PongReceiver extends BroadcastReceiver {
 
+    /**
+     * Logging TAG to identify logs associated with the {@link PingReceiver} or {@link PongReceiver}.
+     */
+    @SuppressWarnings({"FieldCanBeLocal", "WeakerAccess", "unused"}) // SDK implementing app (CY) uses this
+    public static final String TAG = Constants.TAG + ".png";
     /**
      * The human readable name for the background thread handling response and timeout of the ping pong process between
      * background service and foreground facade.
@@ -104,10 +108,10 @@ public class PongReceiver extends BroadcastReceiver {
         this.callback = callback;
 
         // Run receiver on a different thread so it runs even if calling thread waits for it to return:
-
         pongReceiverThread.start();
         Handler receiverHandler = new Handler(pongReceiverThread.getLooper());
-        context.get().registerReceiver(this, new IntentFilter(MessageCodes.getPongActionId(deviceId)), null, receiverHandler);
+        context.get().registerReceiver(this, new IntentFilter(MessageCodes.getPongActionId(deviceId)), null,
+                receiverHandler);
 
         long currentUptimeInMillis = SystemClock.uptimeMillis();
         long offset = unit.toMillis(timeout);

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartSynchronizer.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartSynchronizer.java
@@ -28,11 +28,14 @@ public class StartSynchronizer extends StartUpFinishedHandler {
      *
      * @param lock The lock used for synchronization. Usually a <code>ReentrantLock</code>.
      * @param condition The condition waiting for a signal from this <code>StartSynchronizer</code>.
-     * @param deviceId used to make the global broadcast id in {@link StartUpFinishedHandler} unique
+     * @param appId used to make the global broadcast id in {@link StartUpFinishedHandler} unique.
+     *            This must be a device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
     public StartSynchronizer(final @NonNull Lock lock, final @NonNull Condition condition,
-            @NonNull final String deviceId) {
-        super(deviceId);
+            @NonNull final String appId) {
+        super(appId);
         synchronizer = new Synchronizer(lock, condition);
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/StartUpFinishedHandler.java
@@ -1,7 +1,7 @@
 package de.cyface.datacapturing;
 
-import static de.cyface.synchronization.BundlesExtrasCodes.MEASUREMENT_ID;
 import static de.cyface.datacapturing.Constants.TAG;
+import static de.cyface.synchronization.BundlesExtrasCodes.MEASUREMENT_ID;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -23,8 +23,8 @@ import de.cyface.utils.Validate;
  * @author Armin Schnabel
  * @version 3.0.1
  * @since 2.0.0
- * @see #resume(StartUpFinishedHandler)
- * @see DataCapturingService#start(DataCapturingListener, Vehicle, StartUpFinishedHandler)
+ * @see DataCapturingService#resume(StartUpFinishedHandler)
+ * @see DataCapturingService#start(Vehicle, StartUpFinishedHandler)
  */
 public abstract class StartUpFinishedHandler extends BroadcastReceiver {
 
@@ -34,16 +34,20 @@ public abstract class StartUpFinishedHandler extends BroadcastReceiver {
      */
     private boolean receivedServiceStarted;
     /**
-     * The device id is used to ensure unique broadcast ids between different SDK implementing apps.
-     * For more details see {@link MessageCodes#getServiceStartedActionId(String)}
+     * A device-wide unique identifier for the application containing this SDK such as
+     * {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     * <p>
+     * <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    private final String deviceId;
+    private final String appId;
 
     /**
-     * @param deviceId The device id used to make global broadcast ids unique
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    public StartUpFinishedHandler(String deviceId) {
-        this.deviceId = deviceId;
+    public StartUpFinishedHandler(@NonNull final String appId) {
+        this.appId = appId;
     }
 
     /**
@@ -56,7 +60,7 @@ public abstract class StartUpFinishedHandler extends BroadcastReceiver {
     @Override
     public void onReceive(@NonNull Context context, @NonNull Intent intent) {
         Validate.notNull(intent.getAction());
-        if (intent.getAction().equals(MessageCodes.getServiceStartedActionId(deviceId))) {
+        if (intent.getAction().equals(MessageCodes.getServiceStartedActionId(appId))) {
             receivedServiceStarted = true;
             long measurementIdentifier = intent.getLongExtra(MEASUREMENT_ID, -1L);
             Log.v(TAG, "Received Service started broadcast, mid: " + measurementIdentifier);

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/PingReceiver.java
@@ -1,7 +1,5 @@
 package de.cyface.datacapturing.backend;
 
-import static de.cyface.datacapturing.Constants.BACKGROUND_TAG;
-
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -9,8 +7,9 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import de.cyface.datacapturing.BuildConfig;
-import de.cyface.synchronization.BundlesExtrasCodes;
 import de.cyface.datacapturing.MessageCodes;
+import de.cyface.datacapturing.PongReceiver;
+import de.cyface.synchronization.BundlesExtrasCodes;
 import de.cyface.utils.Validate;
 
 /**
@@ -25,28 +24,35 @@ import de.cyface.utils.Validate;
 public class PingReceiver extends BroadcastReceiver {
 
     /**
-     * The tag used to identify Logcat messages.
+     * Logging TAG to identify logs associated with the {@link PingReceiver} or {@link PongReceiver}.
      */
-    private static final String TAG = BACKGROUND_TAG;
+    private static final String TAG = PongReceiver.TAG;
     /**
-     * The device id used to generate unique broadcast ids
+     * A device-wide unique identifier for the application containing this SDK such as
+     * {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     * <p>
+     * <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    private final String deviceId;
+    private final String appId;
 
     /**
-     * @param deviceId The device id used to generate unique broadcast ids
+     * @param appId A device-wide unique identifier for the application containing this SDK such as
+     *            {@code Context#getPackageName()} which is required to generate unique global broadcasts for this app.
+     *            <b>Attention:</b> The identifier must be identical in the global broadcast sender and receiver.
      */
-    public PingReceiver(String deviceId) {
-        this.deviceId = deviceId;
+    public PingReceiver(@NonNull final String appId) {
+        this.appId = appId;
     }
 
     @Override
     public void onReceive(final @NonNull Context context, final @NonNull Intent intent) {
         Validate.notNull(intent.getAction());
-        if (intent.getAction().equals(MessageCodes.getPingActionId(deviceId))) {
-            Intent pongIntent = new Intent(MessageCodes.getPongActionId(deviceId));
+        Log.v(TAG, "PingReceiver.onReceive()");
+
+        if (intent.getAction().equals(MessageCodes.getPingActionId(appId))) {
+            final Intent pongIntent = new Intent(MessageCodes.getPongActionId(appId));
             if (BuildConfig.DEBUG) {
-                String pingPongIdentifier = intent.getStringExtra(BundlesExtrasCodes.PING_PONG_ID);
+                final String pingPongIdentifier = intent.getStringExtra(BundlesExtrasCodes.PING_PONG_ID);
                 Log.v(TAG, "PingReceiver.onReceive(): Received Ping with identifier " + pingPongIdentifier
                         + ". Sending Pong.");
                 pongIntent.putExtra(BundlesExtrasCodes.PING_PONG_ID, pingPongIdentifier);

--- a/persistence/src/androidTest/AndroidManifest.xml
+++ b/persistence/src/androidTest/AndroidManifest.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="de.cyface.persistence">
+    package="de.cyface.persistence.test">
 
     <!-- The integration test uses a different authority to be executed next to the default app (same device) -->
     <application>
         <provider
             android:name="de.cyface.persistence.MeasuringPointsContentProvider"
-            android:authorities="de.cyface.provider.test"
+            android:authorities="de.cyface.persistence.test.provider"
             android:exported="false"
             android:process=":persistence_process"
             android:syncable="true"

--- a/persistence/src/androidTest/java/de/cyface/persistence/TestUtils.java
+++ b/persistence/src/androidTest/java/de/cyface/persistence/TestUtils.java
@@ -27,7 +27,7 @@ import de.cyface.utils.Validate;
  */
 class TestUtils {
 
-    static final String AUTHORITY = "de.cyface.provider.test";
+    static final String AUTHORITY = "de.cyface.persistence.test.provider";
 
     private static void compareCursorWithValues(final Cursor cursor, final List<ContentValues> contentValues) {
         assertThat(contentValues.size() <= cursor.getCount(), is(equalTo(true)));

--- a/persistence/src/main/AndroidManifest.xml
+++ b/persistence/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
             android:authorities="de.cyface.provider"
             android:exported="false"
             android:process=":persistence_process"
-            android:syncable="true">
-        </provider>
+            android:syncable="true" />
     </application>
 </manifest>

--- a/persistence/src/main/java/de/cyface/persistence/NoDeviceIdException.java
+++ b/persistence/src/main/java/de/cyface/persistence/NoDeviceIdException.java
@@ -10,14 +10,15 @@ import androidx.annotation.NonNull;
  * @since 3.0.0
  * @version 1.0.0
  */
-public final class NoDeviceIdException extends Exception {
+final class NoDeviceIdException extends Exception {
+
     /**
      * Creates a new completely initialized {@link NoDeviceIdException}, providing a detailed explanation
      * about the error to the caller.
      *
      * @param message The explanation of why this error occurred.
      */
-    public NoDeviceIdException(final @NonNull String message) {
+    NoDeviceIdException(final @NonNull String message) {
         super(message);
     }
 }

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -412,7 +412,7 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      * @throws NoDeviceIdException when there are no entries in the {@link IdentifierTable}
      */
     @NonNull
-    public final String loadDeviceId() throws CursorIsNullException, NoDeviceIdException {
+    private String loadDeviceId() throws CursorIsNullException, NoDeviceIdException {
         Cursor deviceIdentifierQueryCursor = null;
         try {
             synchronized (this) {

--- a/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
+++ b/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
@@ -103,6 +103,7 @@ public class WifiSurveyorTest {
         Account account = objectUnderTest.createAccount(TestUtils.DEFAULT_USERNAME, null);
 
         // Make sure the new account is in the expected default state
+        Thread.sleep(1000); // CI emulator seems to be too slow for less
         validateAccountFlags(account);
 
         // Instead of calling startSurveillance as in production we directly call it's implementation
@@ -112,7 +113,7 @@ public class WifiSurveyorTest {
         objectUnderTest.scheduleSyncNow();
         Thread.sleep(1000); // CI emulator seems to be too slow for less
         validateAccountFlags(account);
-        Validate.isTrue(!objectUnderTest.isConnected()); // Ensure default state after startSurveillance
+        assertThat(objectUnderTest.isConnected(), is(equalTo(false))); // Ensure default state after startSurveillance
 
         // Act & Assert 1
         objectUnderTest.setConnected(true);

--- a/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
+++ b/synchronization/src/androidTest/java/de/cyface/synchronization/WifiSurveyorTest.java
@@ -53,7 +53,7 @@ public class WifiSurveyorTest {
     /**
      * An object of the class under test.
      */
-    private WiFiSurveyor objectUnderTest;
+    private WiFiSurveyor oocut;
     /**
      * The {@link AccountManager} to check which accounts are registered.
      */
@@ -69,7 +69,7 @@ public class WifiSurveyorTest {
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         Validate.notNull(connectivityManager);
 
-        objectUnderTest = new WiFiSurveyor(context, connectivityManager, AUTHORITY, ACCOUNT_TYPE);
+        oocut = new WiFiSurveyor(context, connectivityManager, AUTHORITY, ACCOUNT_TYPE);
 
         // Ensure reproducibility
         accountManager = AccountManager.get(context);
@@ -85,7 +85,7 @@ public class WifiSurveyorTest {
                 Validate.isTrue(accountManager.removeAccountExplicitly(oldAccount));
             }
         }
-        objectUnderTest = null;
+        oocut = null;
     }
 
     /**
@@ -100,7 +100,7 @@ public class WifiSurveyorTest {
     public void testSetConnected() throws InterruptedException {
 
         // Arrange
-        Account account = objectUnderTest.createAccount(TestUtils.DEFAULT_USERNAME, null);
+        Account account = oocut.createAccount(TestUtils.DEFAULT_USERNAME, null);
 
         // Make sure the new account is in the expected default state
         Thread.sleep(1000); // CI emulator seems to be too slow for less
@@ -109,22 +109,23 @@ public class WifiSurveyorTest {
         // Instead of calling startSurveillance as in production we directly call it's implementation
         // Without the networkCallback or networkConnectivity BroadcastReceiver as this would make this test
         // flaky when the network changes during the test
-        objectUnderTest.currentSynchronizationAccount = account;
-        objectUnderTest.scheduleSyncNow();
+        oocut.currentSynchronizationAccount = account;
+        oocut.scheduleSyncNow();
         Thread.sleep(1000); // CI emulator seems to be too slow for less
         validateAccountFlags(account);
-        assertThat(objectUnderTest.isConnected(), is(equalTo(false))); // Ensure default state after startSurveillance
+        assertThat(oocut.isConnected(), is(equalTo(false))); // Ensure default state after startSurveillance
 
         // Act & Assert 1
-        objectUnderTest.setConnected(true);
+        oocut.setConnected(true);
         Thread.sleep(1000); // CI emulator seems to be to slow for less
         validateAccountFlags(account);
-        assertThat(objectUnderTest.isConnected(), is(equalTo(true)));
+        assertThat(oocut.isConnected(), is(equalTo(true)));
 
         // Act & Assert 2
-        objectUnderTest.setConnected(false);
+        oocut.setConnected(false);
         Thread.sleep(1000); // CI emulator seems to be to slow for less
-        assertThat(objectUnderTest.isConnected(), is(equalTo(false)));
+        validateAccountFlags(account);
+        assertThat(oocut.isConnected(), is(equalTo(false)));
     }
 
     /**

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/SyncAdapterTest.java
@@ -80,7 +80,7 @@ public final class SyncAdapterTest {
     private Context context;
     private ContentResolver contentResolver;
     private Account account;
-    private SyncAdapter objectUnderTest;
+    private SyncAdapter oocut;
     private AccountManager accountManager;
 
     @Before
@@ -103,7 +103,7 @@ public final class SyncAdapterTest {
         account = new Account(TestUtils.DEFAULT_USERNAME, ACCOUNT_TYPE);
         accountManager.addAccountExplicitly(account, TestUtils.DEFAULT_PASSWORD, null);
 
-        objectUnderTest = new SyncAdapter(context, false, new MockedHttpConnection());
+        oocut = new SyncAdapter(context, false, new MockedHttpConnection());
     }
 
     @After
@@ -150,7 +150,7 @@ public final class SyncAdapterTest {
 
             final Bundle testBundle = new Bundle();
             testBundle.putString(MOCK_IS_CONNECTED_TO_RETURN_TRUE, "");
-            objectUnderTest.onPerformSync(account, testBundle, AUTHORITY, client, result);
+            oocut.onPerformSync(account, testBundle, AUTHORITY, client, result);
         } finally {
             if (client != null) {
                 client.close();
@@ -207,7 +207,7 @@ public final class SyncAdapterTest {
 
             final Bundle testBundle = new Bundle();
             testBundle.putString(MOCK_IS_CONNECTED_TO_RETURN_TRUE, "");
-            objectUnderTest.onPerformSync(account, testBundle, AUTHORITY, client, result);
+            oocut.onPerformSync(account, testBundle, AUTHORITY, client, result);
         } finally {
             if (client != null) {
                 client.close();

--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/UploadProgressTest.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/UploadProgressTest.java
@@ -81,7 +81,7 @@ public class UploadProgressTest {
     private ContentResolver contentResolver;
     private PersistenceLayer<DefaultPersistenceBehaviour> persistenceLayer;
     private AccountManager accountManager;
-    private SyncAdapter objectUnderTest;
+    private SyncAdapter oocut;
     private Account account;
 
     /**
@@ -105,7 +105,7 @@ public class UploadProgressTest {
         account = new Account(TestUtils.DEFAULT_USERNAME, ACCOUNT_TYPE);
         accountManager.addAccountExplicitly(account, TestUtils.DEFAULT_PASSWORD, null);
 
-        objectUnderTest = new SyncAdapter(context, false, new MockedHttpConnection());
+        oocut = new SyncAdapter(context, false, new MockedHttpConnection());
     }
 
     @After
@@ -173,7 +173,7 @@ public class UploadProgressTest {
 
             final Bundle testBundle = new Bundle();
             testBundle.putString(MOCK_IS_CONNECTED_TO_RETURN_TRUE, "");
-            objectUnderTest.onPerformSync(account, testBundle, AUTHORITY, client, result);
+            oocut.onPerformSync(account, testBundle, AUTHORITY, client, result);
 
         } finally {
             if (client != null) {


### PR DESCRIPTION
**Bug was:**
- DataCapturingServiceTests are flaky

**Symptoms were**
- there was a race condition in those tests (for details see MOV-527)
- because of this the ping receiver was sometimes registered after the ping was sent

**Cause was**
- the PingReceiver was registered in BGS.onStartCommand
- the Test is using this call order: startService, bindService, PongReceiver.checkIsRunning()
- bindService() is released as soon as onStartCommand is called but does not wait for it to be finished
- and there we have our race condition - the PingReceiver is sometimes registered slower in onStartCommand than the Test's PongReceiver.checkIsRunning() was sending the Ping itself so the PingReceiver missed the Ping because of it's slow start

**Fix is**
- onBind() is called before onStartCommand so I wanted to move the PingReceiver registration there
- we used the deviceId to make the global broadcasts used app-unique (so that multiple SDK implementing apps don't influence each other)
- now we can't use the deviceId as global broadcast suffix as we have to load it (since recently) from the persistence Layer which requires the authority which we cannot pass to onBind() in the BGS via intent as we do in onStartCommand because the Android documentation (and the reality) says intent extras are ignored!
- for this reason we use the app's package name which only requires the context and is perfect to differentiate between apps on the same device.

**Other Notes**
- I know that it would be cleaner to avoid global broadcasts but I tried this before (high time effort) but failed using local broadcasts or Messengers for ping/pong.
- I have a subtask MOV-659 to make sure SDK implementing apps still don't influence each other with the new app-unique global broadcast suffix