### PR TITLE
Task/mov 727 allow add and remove data capturing listeners

### DIFF
--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/DataCapturingBackgroundServiceTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/DataCapturingBackgroundServiceTest.java
@@ -169,7 +169,7 @@ public class DataCapturingBackgroundServiceTest {
         // bindService() waits for ServiceConnection.onServiceConnected() to be called before returning
         serviceTestRule.bindService(bindIntent, toServiceConnection, 0);
 
-        // Act: Check is DataCapturingBackgroundService is running by sending a Ping
+        // Act: Check if DataCapturingBackgroundService is running by sending a Ping
         checkDataCapturingBackgroundServiceRunning(testCallback);
 
         // Assert

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/DataCapturingBackgroundServiceTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/backend/DataCapturingBackgroundServiceTest.java
@@ -67,12 +67,12 @@ import de.cyface.utils.CursorIsNullException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.3.2
+ * @version 2.3.3
  * @since 2.0.0
  */
 @RunWith(AndroidJUnit4.class)
 @MediumTest
-public class BackgroundServiceTest {
+public class DataCapturingBackgroundServiceTest {
 
     /**
      * Junit rule handling the service connection.

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -90,7 +90,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.4.6
+ * @version 5.4.7
  * @since 1.0.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -493,7 +493,7 @@ public class CapturedDataWriterTest {
      * Tests whether loading a track of geo locations is possible via the {@link PersistenceLayer} object.
      * <p>
      * This test uses predefined timestamps or else it will be flaky, e.g. when storing a location is faster than
-     * storing a event when the test assumes otherwise.
+     * storing an event when the test assumes otherwise.
      *
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
@@ -538,7 +538,7 @@ public class CapturedDataWriterTest {
      * Tests whether loading a track of geo locations is possible via the {@link PersistenceLayer} object.
      * <p>
      * This test uses predefined timestamps or else it will be flaky, e.g. when storing a location is faster than
-     * storing a event when the test assumes otherwise.
+     * storing an event when the test assumes otherwise.
      *
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */

--- a/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
+++ b/datacapturing/src/androidTest/java/de/cyface/datacapturing/model/CapturedDataWriterTest.java
@@ -578,8 +578,9 @@ public class CapturedDataWriterTest {
         assertThat(tracks.size(), is(equalTo(2)));
         assertThat(tracks.get(0).getGeoLocations().size(), is(equalTo(3)));
         assertThat(tracks.get(1).getGeoLocations().size(), is(equalTo(3)));
-        assertThat(tracks.get(1).getGeoLocations().get(1).getTimestamp(), is(equalTo(5L)));
-        assertThat(tracks.get(1).getGeoLocations().get(2).getTimestamp(), is(equalTo(7L)));
+        assertThat(tracks.get(1).getGeoLocations().get(0).getTimestamp(), is(equalTo(5L)));
+        assertThat(tracks.get(1).getGeoLocations().get(1).getTimestamp(), is(equalTo(7L)));
+        assertThat(tracks.get(1).getGeoLocations().get(2).getTimestamp(), is(equalTo(9L)));
     }
 
     /**

--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -60,6 +60,8 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.rule.ServiceTestRule;
 import androidx.test.rule.provider.ProviderTestRule;
+
+import de.cyface.datacapturing.backend.DataCapturingBackgroundService;
 import de.cyface.datacapturing.backend.TestCallback;
 import de.cyface.datacapturing.exception.CorruptedMeasurementException;
 import de.cyface.datacapturing.exception.DataCapturingException;
@@ -757,6 +759,34 @@ public class DataCapturingServiceTest {
             pauseAndCheckThatStopped(measurementIdentifier);
             stopAndCheckThatStopped(-1); // -1 because it's already stopped
         }
+    }
+
+    /**
+     * Tests that removing the {@link DataCapturingListener} during capturing does not stop the
+     * {@link DataCapturingBackgroundService}.
+     *
+     * @throws MissingPermissionException If the test is missing the permission to access the geo location sensor.
+     * @throws DataCapturingException If any unexpected error occurs.
+     * @throws NoSuchMeasurementException Fails the test if the capturing measurement is lost somewhere.
+     * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
+     */
+    @Test
+    public void testRemoveDataCapturingListener() throws MissingPermissionException, DataCapturingException,
+            NoSuchMeasurementException, CursorIsNullException, CorruptedMeasurementException {
+
+        final long measurementIdentifier = startAndCheckThatLaunched();
+        // This happens in SDK implementing apps (SR) when the app is paused and resumed
+        oocut.removeDataCapturingListener(testListener);
+        oocut.addDataCapturingListener(testListener);
+        // Should not happen, we test it anyways
+        oocut.addDataCapturingListener(testListener);
+        pauseAndCheckThatStopped(measurementIdentifier);
+        // Should not happen, we test it anyways
+        oocut.removeDataCapturingListener(testListener);
+        // Should not happen, we test it anyways
+        oocut.removeDataCapturingListener(testListener);
+        resumeAndCheckThatLaunched(measurementIdentifier);
+        stopAndCheckThatStopped(measurementIdentifier);
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -99,7 +99,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 16.1.1
+ * @version 16.1.2
  * @since 1.0.0
  */
 public abstract class DataCapturingService {
@@ -1004,7 +1004,7 @@ public abstract class DataCapturingService {
         /**
          * Creates a new completely initialized <code>FromServiceMessageHandler</code>.
          */
-        FromServiceMessageHandler(final @NonNull Context context,
+        FromServiceMessageHandler(@NonNull final Context context,
                 @NonNull final DataCapturingService dataCapturingService) {
             this.context = context;
             this.listener = new HashSet<>();
@@ -1012,7 +1012,7 @@ public abstract class DataCapturingService {
         }
 
         @Override
-        public void handleMessage(final @NonNull Message msg) {
+        public void handleMessage(@NonNull final Message msg) {
             Log.v(TAG, String.format("Service facade received message: %d", msg.what));
             final Bundle parcel;
             parcel = msg.getData();
@@ -1105,7 +1105,7 @@ public abstract class DataCapturingService {
          * Adds a new {@link DataCapturingListener} interested in events from the
          * {@link DataCapturingBackgroundService}.
          * <p>
-         * All listeners are automatically removed when the {@link DataCapturingService} is killed.
+         * All listeners are automatically removed when the {@link DataCapturingService} is stopped.
          *
          * @param listener A listener that is notified of important events during data capturing.
          * @return true if this collection changed as a result of the call

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -99,7 +99,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 16.1.0
+ * @version 16.1.1
  * @since 1.0.0
  */
 public abstract class DataCapturingService {
@@ -187,7 +187,7 @@ public abstract class DataCapturingService {
     /**
      * The number of ms to wait for the callback, see {@link #isRunning(long, TimeUnit, IsRunningCallback)}.
      */
-    @SuppressWarnings("WeakerAccess") // Used by SDK integrators (CY)
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // Used by SDK integrators (CY)
     public final static long IS_RUNNING_CALLBACK_TIMEOUT = 500L;
     /**
      * The frequency in which sensor data should be captured. If this is higher than the maximum
@@ -347,7 +347,7 @@ public abstract class DataCapturingService {
      *             prior to stopping.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("WeakerAccess") // This life-cycle method is called by sdk implementing apps (e.g. SR)
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // used by sdk implementing apps (e.g. SR)
     public void stop(final @NonNull ShutDownFinishedHandler finishedHandler)
             throws NoSuchMeasurementException, CursorIsNullException {
         Log.d(TAG, "Stopping asynchronously!");
@@ -403,7 +403,7 @@ public abstract class DataCapturingService {
      *             {@link #start(Vehicle, StartUpFinishedHandler)} prior to pausing.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings({"WeakerAccess", "unused"}) // This life-cycle method is called by sdk implementing apps (e.g. SR)
+    @SuppressWarnings({"WeakerAccess", "unused", "RedundantSuppression"}) // used by sdk implementing apps (e.g. SR)
     public void pause(@NonNull final ShutDownFinishedHandler finishedHandler)
             throws DataCapturingException, NoSuchMeasurementException, CursorIsNullException {
         Log.d(TAG, "Pausing asynchronously.");
@@ -462,7 +462,7 @@ public abstract class DataCapturingService {
      *             {@link #start(Vehicle, StartUpFinishedHandler)} prior to pausing.
      * @throws CursorIsNullException If {@link ContentProvider} was inaccessible.
      */
-    @SuppressWarnings("WeakerAccess") // This life-cycle method is called by sdk implementing apps (e.g. SR)
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // used by sdk implementing apps (e.g. SR)
     public void resume(@NonNull final StartUpFinishedHandler finishedHandler) throws DataCapturingException,
             MissingPermissionException, NoSuchMeasurementException, CursorIsNullException {
         Log.d(TAG, "Resuming asynchronously.");
@@ -509,7 +509,7 @@ public abstract class DataCapturingService {
      * @return The identifier used to qualify {@link Measurement}s from this capturing service with the server receiving
      *         the {@code Measurement}s. This needs to be world wide unique.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // sdk implementing apps (SR) uses this to access the device id
+    @SuppressWarnings({"unused", "WeakerAccess", "RedundantSuppression"}) // used by sdk implementing apps (SR)
     public @NonNull String getDeviceIdentifier() {
         return deviceIdentifier;
     }
@@ -518,7 +518,7 @@ public abstract class DataCapturingService {
      * Schedules data synchronization for right now. This does not mean synchronization is going to start immediately.
      * The Android system still decides when it is convenient.
      */
-    @SuppressWarnings({"WeakerAccess", "unused"}) // Used by implementing app (CY)
+    @SuppressWarnings({"WeakerAccess", "unused", "RedundantSuppression"}) // Used by implementing app (CY)
     public void scheduleSyncNow() {
         surveyor.scheduleSyncNow();
     }
@@ -535,7 +535,7 @@ public abstract class DataCapturingService {
      * @param unit The unit of time specified by timeout.
      * @param callback Called as soon as the current state of the service has become clear.
      */
-    @SuppressWarnings("WeakerAccess") // Sdk implementing apps (SR) use this method to check for capturing after resume
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // Used by SDK implementing apps (SR)
     public void isRunning(final long timeout, final TimeUnit unit, final @NonNull IsRunningCallback callback) {
         Log.v(TAG, "Checking isRunning?");
         final PongReceiver pongReceiver = new PongReceiver(getContext(), appId);
@@ -553,7 +553,7 @@ public abstract class DataCapturingService {
      *             background service failed. As there is currently no cleaner method you can capture this exception
      *             softly for now (MOV-588).
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Used by DataCapturingListeners (CY)
+    @SuppressWarnings({"unused", "WeakerAccess", "RedundantSuppression"}) // Used by DataCapturingListeners (CY)
     public void disconnect() throws DataCapturingException {
         unbind();
     }
@@ -571,7 +571,7 @@ public abstract class DataCapturingService {
      *         binding determines the {@code #getIsRunning()} value, see {@code #bind()}.
      * @throws IllegalStateException If communication with background service is not successful.
      */
-    @SuppressWarnings("WeakerAccess") // Used by DataCapturingListeners (CY)
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // Used by DataCapturingListeners (CY)
     public boolean reconnect(final long isRunningTimeout) {
 
         final Lock lock = new ReentrantLock();
@@ -730,7 +730,7 @@ public abstract class DataCapturingService {
      *
      * @return The currently active <code>WiFiSurveyor</code>.
      */
-    @SuppressWarnings("WeakerAccess") // SDK implementing apps (CY) use this to access control the surveyor
+    @SuppressWarnings({"WeakerAccess", "RedundantSuppression"}) // Used by SDK implementing apps (CY)
     public WiFiSurveyor getWiFiSurveyor() {
         return surveyor;
     }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -1126,7 +1126,7 @@ public abstract class DataCapturingService {
          * All listeners are automatically removed when the {@link DataCapturingService} is stopped.
          *
          * @param listener A listener that is notified of important events during data capturing.
-         * @return true if this collection changed as a result of the call
+         * @return {@code True} if this collection changed as a result of the call
          */
         boolean addListener(@NonNull final DataCapturingListener listener) {
             return this.listener.add(listener);
@@ -1138,7 +1138,7 @@ public abstract class DataCapturingService {
          * Listeners may be removed when on Android's onPause Lifecycle method or e.g. when the UI is disabled.
          *
          * @param listener A listener that was registered to be notified of important events during data capturing.
-         * @return true if an element was removed as a result of this call
+         * @return {@code True} if an element was removed as a result of this call
          */
         boolean removeListener(@NonNull final DataCapturingListener listener) {
             return this.listener.remove(listener);

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -63,7 +63,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 14.0.2
+ * @version 14.1.0
  * @since 2.0.0
  */
 public class PersistenceLayer<B extends PersistenceBehaviour> {
@@ -852,7 +852,20 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      * @param measurement The {@code Measurement} which is linked to the {@code Event}.
      */
     public void logEvent(@NonNull final Event.EventType eventType, @NonNull final Measurement measurement) {
-        final long timestamp = System.currentTimeMillis();
+        logEvent(eventType, measurement, System.currentTimeMillis());
+    }
+
+    /**
+     * Stores a new {@link Event} in the {@link PersistenceLayer} which is linked to a {@link Measurement}.
+     * <p>
+     * This interface allows tests to define the timestamp to be used for this event log entry.
+     *
+     * @param eventType The {@link Event.EventType} to be logged.
+     * @param measurement The {@code Measurement} which is linked to the {@code Event}.
+     * @param timestamp The timestamp in ms at which the event was triggered
+     */
+    public void logEvent(@NonNull final Event.EventType eventType, @NonNull final Measurement measurement,
+            final long timestamp) {
         Log.v(TAG,
                 "Storing Event:" + eventType + " for Measurement " + measurement.getIdentifier() + " at " + timestamp);
 


### PR DESCRIPTION
Felix versucht den Akkuverbrauch zu reduzieren indem er seinen CapturingListener bei onPause entfernt und bei onResume wieder hinzufügt. Dafür musste ich die Interfaces hierfür wieder einbauen und außerdem habe ich noch einen Bug gefunden, siehe unten.

Commit-weise reviewen macht hier Sinn.