### PR TITLE
Bug/mov 723 logout does not stop surveillance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,9 @@
 buildscript {
 
     repositories {
-        // Added to find the build tools 3.0.1 dependency below via ./gradlew
+        // Gradle 4.1 and higher include support for Google's Maven repo using
+        // the google() method. And you need to include this repo to download
+        // Android Gradle plugin 3.0.0 or higher.
         google()
         jcenter()
     }

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -40,6 +40,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import de.cyface.utils.Validate;
 
 /**
@@ -48,15 +49,17 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.1.2
+ * @version 7.1.3
  * @since 2.0.0
  */
 public class WiFiSurveyor extends BroadcastReceiver {
 
     /**
      * Logging TAG to identify logs associated with the {@link WiFiSurveyor}.
+     * <p>
+     * SuppressWarnings because SDK implementing app (CY) uses this.
      */
-    @SuppressWarnings({"FieldCanBeLocal", "WeakerAccess", "unused"}) // SDK implementing app (CY) uses this
+    @SuppressWarnings({"FieldCanBeLocal", "WeakerAccess", "unused", "RedundantSuppression"})
     public static final String TAG = Constants.TAG + ".surveyor";
     /**
      * The number of seconds in one minute. This value is used to calculate the data synchronisation interval.
@@ -211,7 +214,7 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * 
      * @throws SynchronisationException If no current Android <code>Context</code> is available.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Used by CyfaceDataCapturingService
+    @SuppressWarnings({"unused", "WeakerAccess", "RedundantSuppression"}) // Used by CyfaceDataCapturingService
     public void stopSurveillance() throws SynchronisationException {
         if (context.get() == null) {
             throw new SynchronisationException("No valid context available!");
@@ -283,13 +286,16 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * Deletes a Cyface account from the Android {@code Account} system. Does silently nothing if no such
      * <code>Account</code> exists.
      * <p>
+     * <b>Attention:</b> You need to call {@link #stopSurveillance()} before calling this method as the
+     * {@link WiFiSurveyor} surveillance expects a registered account to work.
+     * <p>
      * <b>ATTENTION:</b> SDK implementing apps which cannot use this method to remove an account need to call
      * {@code ContentResolver#removePeriodicSync()} themselves.
      *
      * @param username The username of the account to delete.
      */
     @SuppressWarnings("unused") // {@link MovebisDataCapturingService} uses this to deregister a token
-    public void deleteAccount(final @NonNull String username) {
+    public void deleteAccount(@NonNull final String username) {
         final AccountManager accountManager = AccountManager.get(context.get());
         final Account account = new Account(username, accountType);
 
@@ -507,7 +513,7 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * This method must not be called before {@link #startSurveillance(Account)} linked a currentSynchronizationAccount.
      * <p>
      * If you change the implementation of this method, make sure you adjust
-     * {@link SyncAdapter#isConnected(Account, String)} accordingly.
+     * {@code SyncAdapter#isConnected(Account, String)} accordingly.
      * <p>
      * This method allows implementing apps (CY) to only trigger sync manually when connected or else show an info.
      *

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorTest.java
@@ -52,6 +52,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
+
 import de.cyface.utils.Validate;
 
 /**
@@ -70,7 +71,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.1
+ * @version 2.0.2
  * @since 2.0.0
  */
 @RunWith(RobolectricTestRunner.class)
@@ -156,7 +157,6 @@ public class WiFiSurveyorTest {
 
     /**
      * Tests if mobile and WiFi connectivity is detected correctly if both are allowed.
-     *
      */
     @Test
     public void testMobileConnectivity() throws SynchronisationException {
@@ -200,7 +200,7 @@ public class WiFiSurveyorTest {
      */
     private void setWiFiConnectivity(final boolean connected, @NonNull final WiFiSurveyor surveyor) {
 
-        setConnectivity(connected, true, oocut);
+        setConnectivity(connected, true, surveyor);
     }
 
     /**
@@ -212,7 +212,7 @@ public class WiFiSurveyorTest {
      */
     private void setMobileConnectivity(final boolean connected, @NonNull final WiFiSurveyor surveyor) {
 
-        setConnectivity(connected, false, oocut);
+        setConnectivity(connected, false, surveyor);
     }
 
     /**


### PR DESCRIPTION
This should fix the bug where the WifiSurveillance Service crashes after a user logs out and the NetworkConnection is reestablished.