### PR TITLE
Bug/mov 763 validation exceptions on sync logout

### DIFF
--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -64,7 +64,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 14.1.1
+ * @version 14.1.2
  * @since 2.0.0
  */
 public class PersistenceLayer<B extends PersistenceBehaviour> {
@@ -407,6 +407,7 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      *
      * @return The device is as string
      */
+    @NonNull
     public final String restoreOrCreateDeviceId() throws CursorIsNullException {
         try {
             return loadDeviceId();

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
@@ -76,7 +76,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.2
+ * @version 2.0.3
  * @since 2.0.0
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
@@ -124,7 +124,7 @@ public class SyncPerformerTest {
     public void testSendData_returnsTrueWhenServerReturns409() throws CursorIsNullException, NoSuchMeasurementException,
             ServerUnavailableException, ForbiddenException, BadRequestException, ConflictException,
             UnauthorizedException, InternalServerErrorException, EntityNotParsableException, SynchronisationException,
-            NetworkUnavailableException {
+            NetworkUnavailableException, SynchronizationInterruptedException {
 
         // Arrange
         // Insert data to be synced

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -74,7 +74,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 2.0.1
  * @since 2.0.0
  */
 public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
@@ -137,7 +137,6 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
         final String freshAuthToken;
         final String password = accountManager.getPassword(account);
         if (password == null) {
-            Validate.notNull(response);
             return getLoginActivityIntent(response, account, authTokenType);
         }
 
@@ -189,7 +188,7 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
      * @return the {@link Bundle} containing the requesting {@code Intent}
      */
     @Nullable
-    private Bundle getLoginActivityIntent(@NonNull final AccountAuthenticatorResponse response,
+    private Bundle getLoginActivityIntent(@Nullable final AccountAuthenticatorResponse response,
             @NonNull final Account account, @NonNull final String authTokenType) {
         if (LOGIN_ACTIVITY == null) {
             Log.w(TAG, "Please set LOGIN_ACTIVITY.");

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -34,7 +34,7 @@ import androidx.annotation.NonNull;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 6.0.0
+ * @version 7.0.0
  * @since 3.0.0
  */
 interface Http {
@@ -113,6 +113,8 @@ interface Http {
      * @throws EntityNotParsableException When the server returns {@link HttpConnection#HTTP_ENTITY_NOT_PROCESSABLE}
      * @throws InternalServerErrorException When the server returns {@code HttpURLConnection#HTTP_INTERNAL_ERROR}
      * @throws NetworkUnavailableException When the network used for transmission becomes unavailable.
+     * @throws SynchronizationInterruptedException When the transmission stream ended too early, likely because the sync
+     *             thread was interrupted (sync canceled)
      */
     @SuppressWarnings("UnusedReturnValue") // May be used in the future
     @NonNull
@@ -120,5 +122,6 @@ interface Http {
             @NonNull final SyncAdapter.MetaData metaData, @NonNull final String fileName,
             @NonNull final UploadProgressListener progressListener)
             throws SynchronisationException, BadRequestException, UnauthorizedException, InternalServerErrorException,
-            ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException;
+            ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
+            SynchronizationInterruptedException;
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -286,7 +286,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     /**
-     * Checks weather the network was disconnected or the synchronization was interrupted.
+     * Checks whether the network was disconnected or the synchronization was interrupted.
      *
      * @return {@code True} if the synchronization shall be canceled.
      * @param account The {@code Account} which is used for synchronization

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -23,9 +23,11 @@ import static de.cyface.synchronization.Constants.TAG;
 import static de.cyface.utils.ErrorHandler.sendErrorIntent;
 import static de.cyface.utils.ErrorHandler.ErrorCode.AUTHENTICATION_ERROR;
 import static de.cyface.utils.ErrorHandler.ErrorCode.DATABASE_ERROR;
+import static de.cyface.utils.ErrorHandler.ErrorCode.SYNCHRONIZATION_INTERRUPTED;
 import static java.lang.Thread.interrupted;
 
 import java.io.File;
+import java.io.InterruptedIOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -67,7 +69,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.6.6
+ * @version 2.6.7
  * @since 2.0.0
  */
 public final class SyncAdapter extends AbstractThreadedSyncAdapter {
@@ -122,130 +124,64 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
     public void onPerformSync(@NonNull final Account account, @NonNull final Bundle extras,
             @NonNull final String authority, @NonNull final ContentProviderClient provider,
             @NonNull final SyncResult syncResult) {
+
         // This allows us to mock the #isConnected() check for unit tests
         mockIsConnectedToReturnTrue = extras.containsKey(MOCK_IS_CONNECTED_TO_RETURN_TRUE);
 
-        // If WifiSurveyor.shutdownSurveillance was called in the meantime, cancel sync:
-        if (interrupted()) {
-            Log.w(TAG, "Sync interrupted, aborting sync.");
-            return;
-        }
-
-        // The network setting may have changed since the initial sync call, avoid unnecessary serialization
-        if (!isConnected(account, authority)) {
-            Log.w(TAG, "Sync aborted: syncable connection not available anymore");
+        if (isSyncRequestAborted(account, authority)) {
             return;
         }
 
         Log.d(TAG, "Sync started");
-
         final Context context = getContext();
         final MeasurementSerializer serializer = new MeasurementSerializer(new DefaultFileAccess());
         final PersistenceLayer<DefaultPersistenceBehaviour> persistence = new PersistenceLayer<>(context,
                 context.getContentResolver(), authority, new DefaultPersistenceBehaviour());
+        final CyfaceAuthenticator authenticator = new CyfaceAuthenticator(context);
+        final SyncPerformer syncPerformer = new SyncPerformer(context);
 
         try {
-            final SyncPerformer syncPerformer = new SyncPerformer(context);
-
-            // Load api url
-            final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-            final String endPointUrl = preferences.getString(SyncService.SYNC_ENDPOINT_URL_SETTINGS_KEY, null);
-            Validate.notNull(endPointUrl,
-                    "Sync canceled: Server url not available. Please set the applications server url preference.");
-
-            // Setup required device identifier, if not already existent
-            final String deviceId = persistence.restoreOrCreateDeviceId();
-            Validate.notNull(deviceId);
-
             // Ensure user is authorized before starting synchronization
-            final CyfaceAuthenticator authenticator = new CyfaceAuthenticator(context);
-            String jwtAuthToken;
-            try {
-                // Explicitly calling CyfaceAuthenticator.getAuthToken(), see its documentation
-                final Bundle bundle = authenticator.getAuthToken(null, account, AUTH_TOKEN_TYPE, null);
-                if (bundle == null) {
-                    // Because of Movebis we don't throw an IllegalStateException if there is no auth token
-                    throw new AuthenticatorException("No valid auth token supplied. Aborting data synchronization!");
-                }
-                jwtAuthToken = bundle.getString(AccountManager.KEY_AUTHTOKEN);
-            } catch (final NetworkErrorException e) {
-                // This happened e.g. when Wifi was manually disabled just after synchronization started (Pixel 2 XL).
-                Log.w(TAG, "getAuthToken failed, was the connection closed? Aborting sync.");
-                return;
-            }
-            // When WifiSurveyor.deleteAccount() was called in the meantime the jwt token is empty, thus:
-            if (interrupted()) {
-                Log.w(TAG, "Sync interrupted, aborting sync.");
-                return;
-            }
-            Validate.notNull(jwtAuthToken);
-            Log.d(TAG, "Login authToken: **" + jwtAuthToken.substring(jwtAuthToken.length() - 7));
+            getAuthToken(authenticator, account);
+            final String deviceId = persistence.restoreOrCreateDeviceId();
 
-            // Load all Measurements that are finished capturing
-            final List<Measurement> syncableMeasurements = persistence.loadMeasurements(MeasurementStatus.FINISHED);
-
+            // Inform ConnectionStatusListener
             for (final ConnectionStatusListener listener : progressListener) {
                 listener.onSyncStarted();
             }
+
+            // Load all Measurements ready for synchronization
+            final List<Measurement> syncableMeasurements = persistence.loadMeasurements(MeasurementStatus.FINISHED);
             if (syncableMeasurements.size() == 0) {
                 return; // nothing to sync
             }
 
             for (final Measurement measurement : syncableMeasurements) {
-
-                // Load measurement with metadata
                 Log.d(Constants.TAG,
                         String.format("Measurement with identifier %d is about to be loaded for transmission.",
                                 measurement.getIdentifier()));
+
+                // Load measurement data
                 final MeasurementContentProviderClient loader = new MeasurementContentProviderClient(
                         measurement.getIdentifier(), provider, authority);
                 final MetaData metaData = loadMetaData(measurement, persistence, deviceId, context);
 
-                // The network setting may have changed since the initial sync call, avoid unnecessary serialization
-                if (!isConnected(account, authority)) {
-                    Log.w(TAG, "Sync aborted: syncable connection not available anymore");
-                    return;
-                }
-                // Load compressed transfer file for measurement
+                // Load, try to sync the file to be transferred and clean it up afterwards
                 File compressedTransferTempFile = null;
-
-                // Try to sync the transfer file - remove it afterwards
                 try {
                     compressedTransferTempFile = serializer.writeSerializedCompressed(loader,
                             measurement.getIdentifier(), persistence);
 
                     // Acquire new auth token before each synchronization (old one could be expired)
-                    try {
-                        // Explicitly calling CyfaceAuthenticator.getAuthToken(), see its documentation
-                        final Bundle authBundle = authenticator.getAuthToken(null, account, AUTH_TOKEN_TYPE, null);
-                        Validate.notNull(authBundle);
-                        jwtAuthToken = authBundle.getString(AccountManager.KEY_AUTHTOKEN);
-                    } catch (final NetworkErrorException e) {
-                        // This happened e.g. when Wifi was manually disabled just after synchronization started (Pixel
-                        // 2 XL).
-                        Log.w(TAG, "getAuthToken failed, was the connection closed? Aborting sync.");
-                        return;
-                    }
-                    // When WifiSurveyor.deleteAccount() was called in the meantime the jwt token is empty, thus:
-                    if (interrupted()) {
-                        Log.w(TAG, "Sync interrupted, aborting sync.");
-                        return;
-                    }
-                    Validate.notNull(jwtAuthToken);
-                    Log.d(TAG, "Sync authToken: **" + jwtAuthToken.substring(jwtAuthToken.length() - 7));
+                    final String jwtAuthToken = getAuthToken(authenticator, account);
+                    final String endPointUrl = getApiUrl(context);
 
-                    // The network setting may have changed since the initial sync call, avoid using metered network
-                    // without permission
-
-                    if (!isConnected(account, authority)) {
-                        Log.w(TAG, "Sync aborted: syncable connection not available anymore");
+                    // Check whether the network settings changed to avoid using metered network without permission
+                    if (isSyncRequestAborted(account, authority)) {
                         return;
                     }
 
                     // Synchronize measurement
-                    Log.d(de.cyface.persistence.Constants.TAG, String.format("Transferring compressed measurement (%s)",
-                            DefaultFileAccess.humanReadableByteCount(compressedTransferTempFile.length(), true)));
-                    Validate.notNull(endPointUrl);
                     final boolean transmissionSuccessful = syncPerformer.sendData(http, syncResult, endPointUrl,
                             metaData, compressedTransferTempFile, new UploadProgressListener() {
                                 @Override
@@ -262,10 +198,10 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
                     // Mark successfully transmitted measurement as synced
                     try {
                         persistence.markAsSynchronized(measurement);
+                        Log.d(Constants.TAG, "Measurement marked as synced.");
                     } catch (final NoSuchMeasurementException e) {
                         throw new IllegalStateException(e);
                     }
-                    Log.d(Constants.TAG, "Measurement marked as synced.");
 
                 } finally {
                     if (compressedTransferTempFile != null && compressedTransferTempFile.exists()) {
@@ -281,12 +217,94 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
             Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
             syncResult.stats.numAuthExceptions++;
             sendErrorIntent(context, AUTHENTICATION_ERROR.getCode(), e.getMessage());
+        } catch (final InterruptedIOException e) {
+            Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
+            syncResult.stats.numIoExceptions++;
+            sendErrorIntent(context, SYNCHRONIZATION_INTERRUPTED.getCode(), e.getMessage());
+        } catch (final NetworkErrorException e) {
+            Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
+            syncResult.stats.numIoExceptions++;
+            sendErrorIntent(context, SYNCHRONIZATION_INTERRUPTED.getCode(), e.getMessage());
         } finally {
             Log.d(TAG, String.format("Sync finished. (%s)", syncResult.hasError() ? "ERROR" : "success"));
             for (final ConnectionStatusListener listener : progressListener) {
                 listener.onSyncFinished();
             }
         }
+    }
+
+    /**
+     * Gets the authentication token from the {@link CyfaceAuthenticator}.
+     * 
+     * @param authenticator The {@code CyfaceAuthenticator} to be used
+     * @param account The {@code Account} to get the token for
+     * @return The token as string
+     * @throws AuthenticatorException If no token was supplied which must be supported for implementing apps (SR)
+     * @throws NetworkErrorException If the network authentication request failed for any reasons
+     * @throws InterruptedIOException If the synchronization was {@link Thread#interrupted()}.
+     */
+    private String getAuthToken(@NonNull final CyfaceAuthenticator authenticator, @NonNull final Account account)
+            throws AuthenticatorException, NetworkErrorException, InterruptedIOException {
+
+        String jwtAuthToken;
+        // Explicitly calling CyfaceAuthenticator.getAuthToken(), see its documentation
+        final Bundle bundle;
+        try {
+            bundle = authenticator.getAuthToken(null, account, AUTH_TOKEN_TYPE, null);
+        } catch (final NetworkErrorException e) {
+            // This happened e.g. when Wifi was manually disabled just after synchronization started (Pixel 2 XL).
+            Log.w(TAG, "getAuthToken failed, was the connection closed? Aborting sync.");
+            throw e;
+        }
+        if (bundle == null) {
+            // Because of Movebis we don't throw an IllegalStateException if there is no auth token
+            throw new AuthenticatorException("No valid auth token supplied. Aborting data synchronization!");
+        }
+        jwtAuthToken = bundle.getString(AccountManager.KEY_AUTHTOKEN);
+        // When WifiSurveyor.deleteAccount() was called in the meantime the jwt token is empty, thus:
+        if (interrupted()) {
+            throw new InterruptedIOException("Sync interrupted, aborting sync.");
+        }
+        Validate.notNull(jwtAuthToken);
+        Log.d(TAG, "Login authToken: **" + jwtAuthToken.substring(jwtAuthToken.length() - 7));
+        return jwtAuthToken;
+    }
+
+    /**
+     * Reads the Collector API URL from the preferences.
+     *
+     * @param context The {@code Context} required to read the preferences
+     * @return The URL as string
+     */
+    @NonNull
+    private String getApiUrl(@NonNull final Context context) {
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String endPointUrl = preferences.getString(SyncService.SYNC_ENDPOINT_URL_SETTINGS_KEY, null);
+        Validate.notNull(endPointUrl,
+                "Sync canceled: Server url not available. Please set the applications server url preference.");
+        // noinspection ConstantConditions - cannot be null because of the validation
+        return endPointUrl;
+    }
+
+    /**
+     * Checks weather the network was disconnected or the synchronization was interrupted.
+     *
+     * @return {@code True} if the synchronization shall be canceled.
+     * @param account The {@code Account} which is used for synchronization
+     * @param authority The authority which is used for synchronization
+     */
+    private boolean isSyncRequestAborted(@NonNull final Account account, @NonNull final String authority) {
+        if (interrupted()) {
+            Log.w(TAG, "Sync interrupted, aborting sync.");
+            return true;
+        }
+
+        if (!isConnected(account, authority)) {
+            Log.w(TAG, "Sync aborted: syncable connection not available anymore");
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -27,7 +27,6 @@ import static de.cyface.utils.ErrorHandler.ErrorCode.SYNCHRONIZATION_INTERRUPTED
 import static java.lang.Thread.interrupted;
 
 import java.io.File;
-import java.io.InterruptedIOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -69,7 +68,7 @@ import de.cyface.utils.Validate;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.6.7
+ * @version 2.6.8
  * @since 2.0.0
  */
 public final class SyncAdapter extends AbstractThreadedSyncAdapter {
@@ -217,7 +216,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
             Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
             syncResult.stats.numAuthExceptions++;
             sendErrorIntent(context, AUTHENTICATION_ERROR.getCode(), e.getMessage());
-        } catch (final InterruptedIOException e) {
+        } catch (final SynchronizationInterruptedException e) {
             Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
             syncResult.stats.numIoExceptions++;
             sendErrorIntent(context, SYNCHRONIZATION_INTERRUPTED.getCode(), e.getMessage());
@@ -241,10 +240,10 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
      * @return The token as string
      * @throws AuthenticatorException If no token was supplied which must be supported for implementing apps (SR)
      * @throws NetworkErrorException If the network authentication request failed for any reasons
-     * @throws InterruptedIOException If the synchronization was {@link Thread#interrupted()}.
+     * @throws SynchronizationInterruptedException If the synchronization was {@link Thread#interrupted()}.
      */
     private String getAuthToken(@NonNull final CyfaceAuthenticator authenticator, @NonNull final Account account)
-            throws AuthenticatorException, NetworkErrorException, InterruptedIOException {
+            throws AuthenticatorException, NetworkErrorException, SynchronizationInterruptedException {
 
         String jwtAuthToken;
         // Explicitly calling CyfaceAuthenticator.getAuthToken(), see its documentation
@@ -263,7 +262,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
         jwtAuthToken = bundle.getString(AccountManager.KEY_AUTHTOKEN);
         // When WifiSurveyor.deleteAccount() was called in the meantime the jwt token is empty, thus:
         if (interrupted()) {
-            throw new InterruptedIOException("Sync interrupted, aborting sync.");
+            throw new SynchronizationInterruptedException("Sync interrupted, aborting sync.");
         }
         Validate.notNull(jwtAuthToken);
         Log.d(TAG, "Login authToken: **" + jwtAuthToken.substring(jwtAuthToken.length() - 7));

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
@@ -20,6 +20,7 @@ package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.TAG;
 import static de.cyface.synchronization.CyfaceAuthenticator.loadSslContext;
+import static de.cyface.utils.ErrorHandler.ErrorCode.SYNCHRONIZATION_INTERRUPTED;
 import static de.cyface.utils.ErrorHandler.sendErrorIntent;
 import static de.cyface.utils.ErrorHandler.ErrorCode.BAD_REQUEST;
 import static de.cyface.utils.ErrorHandler.ErrorCode.ENTITY_NOT_PARSABLE;
@@ -54,7 +55,7 @@ import de.cyface.persistence.DefaultFileAccess;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 3.1.2
+ * @version 3.1.3
  * @since 2.0.0
  */
 class SyncPerformer {
@@ -164,6 +165,10 @@ class SyncPerformer {
         } catch (final NetworkUnavailableException e) {
             syncResult.stats.numIoExceptions++;
             sendErrorIntent(context, NETWORK_UNAVAILABLE.getCode(), e.getMessage());
+            return false;
+        } catch (final SynchronizationInterruptedException e) {
+            syncResult.stats.numIoExceptions++;
+            sendErrorIntent(context, SYNCHRONIZATION_INTERRUPTED.getCode(), e.getMessage());
             return false;
         } catch (final ConflictException e) {
             syncResult.stats.numSkippedEntries++;

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
@@ -20,13 +20,13 @@ package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.TAG;
 import static de.cyface.synchronization.CyfaceAuthenticator.loadSslContext;
-import static de.cyface.utils.ErrorHandler.ErrorCode.NETWORK_UNAVAILABLE;
 import static de.cyface.utils.ErrorHandler.sendErrorIntent;
 import static de.cyface.utils.ErrorHandler.ErrorCode.BAD_REQUEST;
 import static de.cyface.utils.ErrorHandler.ErrorCode.ENTITY_NOT_PARSABLE;
 import static de.cyface.utils.ErrorHandler.ErrorCode.FORBIDDEN;
 import static de.cyface.utils.ErrorHandler.ErrorCode.INTERNAL_SERVER_ERROR;
 import static de.cyface.utils.ErrorHandler.ErrorCode.MALFORMED_URL;
+import static de.cyface.utils.ErrorHandler.ErrorCode.NETWORK_UNAVAILABLE;
 import static de.cyface.utils.ErrorHandler.ErrorCode.SERVER_UNAVAILABLE;
 import static de.cyface.utils.ErrorHandler.ErrorCode.SYNCHRONIZATION_ERROR;
 import static de.cyface.utils.ErrorHandler.ErrorCode.UNAUTHORIZED;
@@ -46,13 +46,15 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import de.cyface.persistence.DefaultFileAccess;
+
 /**
  * Performs the actual synchronisation with a provided server, by uploading meta data and a file containing
  * measurements.
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 3.1.1
+ * @version 3.1.2
  * @since 2.0.0
  */
 class SyncPerformer {
@@ -109,6 +111,8 @@ class SyncPerformer {
             @NonNull final File compressedTransferTempFile, @NonNull final UploadProgressListener progressListener,
             @NonNull final String jwtAuthToken) {
 
+        Log.d(de.cyface.persistence.Constants.TAG, String.format("Transferring compressed measurement (%s)",
+                DefaultFileAccess.humanReadableByteCount(compressedTransferTempFile.length(), true)));
         HttpsURLConnection.setFollowRedirects(false);
         HttpsURLConnection connection = null;
         final String fileName = String.format(Locale.US, "%s_%d.cyf", metaData.deviceId, metaData.measurementId);

--- a/synchronization/src/main/java/de/cyface/synchronization/SynchronizationInterruptedException.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SynchronizationInterruptedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Cyface GmbH
+ *
+ * This file is part of the Cyface SDK for Android.
+ *
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.synchronization;
+
+import androidx.annotation.NonNull;
+
+/**
+ * An {@code Exception} thrown when the synchronization is interrupted.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 4.0.1
+ */
+public class SynchronizationInterruptedException extends Exception {
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this {@code Exception}.
+     */
+    SynchronizationInterruptedException(@NonNull final String detailedMessage) {
+        super(detailedMessage);
+    }
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this {@code Exception}.
+     * @param cause The {@code Exception} that caused this one.
+     */
+    @SuppressWarnings("unused") // May be used in the future
+    public SynchronizationInterruptedException(@NonNull final String detailedMessage, @NonNull final Exception cause) {
+        super(detailedMessage, cause);
+    }
+}

--- a/utils/src/main/java/de/cyface/utils/ErrorHandler.java
+++ b/utils/src/main/java/de/cyface/utils/ErrorHandler.java
@@ -21,7 +21,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
  * support time for all involved.
  *
  * @author Armin Schnabel
- * @version 1.3.0
+ * @version 1.4.0
  * @since 2.2.0
  */
 public class ErrorHandler extends BroadcastReceiver {
@@ -161,6 +161,10 @@ public class ErrorHandler extends BroadcastReceiver {
                 errorMessage = context.getString(R.string.error_message_network_unavailable);
                 break;
 
+            case SYNCHRONIZATION_INTERRUPTED:
+                errorMessage = context.getString(R.string.error_message_synchronization_interrupted);
+                break;
+
             default:
                 errorMessage = context.getString(R.string.error_message_unknown_error);
         }
@@ -183,7 +187,8 @@ public class ErrorHandler extends BroadcastReceiver {
                 4), NETWORK_ERROR(5), DATABASE_ERROR(6), AUTHENTICATION_ERROR(7), AUTHENTICATION_CANCELED(
                         8), SYNCHRONIZATION_ERROR(9), DATA_TRANSMISSION_ERROR(10), SSL_CERTIFICATE_UNKNOWN(
                                 11), BAD_REQUEST(12), FORBIDDEN(13), INTERNAL_SERVER_ERROR(
-                                        14), ENTITY_NOT_PARSABLE(15), NETWORK_UNAVAILABLE(16);
+                                        14), ENTITY_NOT_PARSABLE(
+                                                15), NETWORK_UNAVAILABLE(16), SYNCHRONIZATION_INTERRUPTED(17);
         // MEASUREMENT_ENTRY_IS_IRRETRIEVABLE(X),
 
         private final int code;

--- a/utils/src/main/res/values-de/strings.xml
+++ b/utils/src/main/res/values-de/strings.xml
@@ -23,6 +23,7 @@
     <string name="error_message_internal_server_error">Interner Server Fehler</string>
     <string name="error_message_entity_not_parsable">Anfrage nicht lesbar</string>
     <string name="error_message_network_unavailable">Verbindungsabbruch</string>
+    <string name="error_message_synchronization_interrupted">Synchronisierung unterbrochen</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unerwarteter Fehler</string>

--- a/utils/src/main/res/values/strings.xml
+++ b/utils/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="error_message_internal_server_error">Internal server error</string>
     <string name="error_message_entity_not_parsable">Request not readable</string>
     <string name="error_message_network_unavailable">Connection interrupted</string>
+    <string name="error_message_synchronization_interrupted">Synchronization interrupted</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unexpected error</string>


### PR DESCRIPTION
Ich konnte noch Exceptions herbeiführen, wenn ich mich ausgeloggt habe und gleichzeitig mit der Synchronisation / Verbindung herumgespielt habe.

Um das zu fixen, habe ich zum einen onPerformSync etwas aufgeräumt - die Methode war vorher ja viel zu lange, und zum anderen fange ich noch Exceptions ab, die legitimerweise auftreten können, siehe Code, und werfe getypte Exceptions.

Mit dem Code hier konnte ich jetzt keine Exceptions mehr herbeiführen. Automatisch lies sich das leider nicht wirklich testen.