### PR TITLE
Fix/5.0.0 beta3/cy 5042

### DIFF
--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -16,6 +16,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Create empty truststore file
+      run: |
+        # When no truststore is required by the server we create an empty file or else the build fails
+        mkdir -p synchronization/src/main/res/raw
+        touch synchronization/src/main/res/raw/truststore.jks
     - name: Create local.properties with a read token
       run: |
         # Use a personal read token to install the Cyface Utils package

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.6.2
+ * @version 2.6.3
  * @since 1.0.0
  */
 
@@ -37,7 +37,7 @@ buildscript {
 
 ext {
     // This libraries version
-    cyfaceBackendVersion = "5.0.0-beta2"
+    cyfaceBackendVersion = "5.0.0-beta3"
 
     // Cyface dependencies
     cyfaceUtilsVersion = "1.1.3"


### PR DESCRIPTION
This should fix the Build of the new Github Actions Workflow:
https://github.com/cyface-de/android-backend/commit/61509cc4aa4c2e6aa38082747f32c4ad694534cf/checks?check_suite_id=343849693

We do this step also in our Bitrise CI Workflow which is why it did not fail there.