### PR TITLE
Task/dat 129/upgrade android sdk to 29

### DIFF
--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -16,6 +16,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Create empty truststore file
+      run: |
+        # When no truststore is required by the server we create an empty file or else the build fails
+        mkdir -p synchronization/src/main/res/raw
+        touch synchronization/src/main/res/raw/truststore.jks
     - name: Create local.properties with a read token
       run: |
         # Use a personal read token to install the Cyface Utils package

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.6.2
+ * @version 2.7.0
  * @since 1.0.0
  */
 
@@ -43,7 +43,7 @@ ext {
     cyfaceUtilsVersion = "1.1.3"
 
     minSdkVersion = 16
-    targetSdkVersion = 28
+    targetSdkVersion = 29
     compileSdkVersion = 29
     buildToolsVersion = '29.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ ext {
 
     minSdkVersion = 16
     targetSdkVersion = 28
-    compileSdkVersion = 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion = 29
+    buildToolsVersion = '29.0.0'
 
     androidxAnnotationVersion = "1.0.0"
     androidxAppCompatVersion = "1.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     cyfaceBackendVersion = "5.0.0-beta2"
 
     // Cyface dependencies
-    cyfaceUtilsVersion = "1.1.3"
+    cyfaceUtilsVersion = "1.2.1"
 
     minSdkVersion = 16
     targetSdkVersion = 29

--- a/datacapturing/src/main/AndroidManifest.xml
+++ b/datacapturing/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <!-- Required to keep the app from being send to sleep by the system. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Required to access GNSS location providers -->
+    <!-- (!) We do *not* need ACCESS_BACKGROUND_LOCATION as we only need location in Foreground Service-->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- Required to change periodic synchronisation intervals in the background -->
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
@@ -15,11 +16,19 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>
-        <!-- Declares the data capturing service which is not exported to other applications. Most important is the android:process declaration with the ":" in the beginning. It tells the system to run the service in its own process. -->
+        <!-- Declares the data capturing service which is not exported to other applications.
+        Most important is the android:process declaration with the ":" in the beginning.
+        It tells the system to run the service in its own process. -->
+        <!-- Foreground services in Q+ require type 'location' to get the location when the app
+        is minimized. ACCESS_FINE_LOCATION and foregroundServiceType="location" is enough on Q+
+        as long as we target the Q+ API. -->
+        <!-- The "unused attribute" warning for foregroundServiceType can be ignored as this declaration
+        requirement was added in Android Q so no handling is required for lower APIs. -->
         <service
             android:name=".backend.DataCapturingBackgroundService"
             android:description="@string/capturing_service_description"
             android:exported="false"
+            android:foregroundServiceType="location"
             android:process=":capturing_process" />
     </application>
 </manifest>


### PR DESCRIPTION
The SDK now targets Android Q.
This allows us to declare that our SDK does not need the new "Background Location" permission.
This permission is only required for non-user-initiated location requests.
We, however, only check the location when the App is in foreground or in our foreground service (datacapturing).

However, when targeting Android Q we need the new "foregroundServiceType: location" flag in the manifest for the datacapturing service for this to work.

Thus, this flag was added.