### PR TITLE
Bug/dat 382 event time offset set more than once

### DIFF
--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -28,7 +28,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Process;
@@ -203,11 +202,7 @@ public class PongReceiver extends BroadcastReceiver {
 
     private void quitBackgroundHandlerThread() {
         if (Thread.currentThread().getName().equals(pongReceiverThread.getName())) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                pongReceiverThread.quitSafely();
-            } else {
-                pongReceiverThread.quit();
-            }
+            pongReceiverThread.quitSafely();
         }
     }
 }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/PongReceiver.java
@@ -28,6 +28,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Process;
@@ -202,7 +203,11 @@ public class PongReceiver extends BroadcastReceiver {
 
     private void quitBackgroundHandlerThread() {
         if (Thread.currentThread().getName().equals(pongReceiverThread.getName())) {
-            pongReceiverThread.quitSafely();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                pongReceiverThread.quitSafely();
+            } else {
+                pongReceiverThread.quit();
+            }
         }
     }
 }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -244,7 +244,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
     @Override
     public synchronized void onSensorChanged(final @NonNull SensorEvent event) {
         if (eventTimeOffsetMillis == null) {
-            eventTimeOffsetMillis = eventTimeOffset(event);
+            eventTimeOffsetMillis = eventTimeOffset(event.timestamp);
         }
         Validate.notNull(eventTimeOffsetMillis);
         long thisSensorEventTime = event.timestamp / 1_000_000L + eventTimeOffsetMillis;
@@ -290,10 +290,10 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
      * As we only use `SystemClock` to calculate the offset (e.g. bootTime) this approach should
      * allow to synchronize the event timestamps between phones by syncing their system time.
      *
-     * @param event the {@code SensorEvent} to be used to determine the time offset
+     * @param eventTimeNanos the timestamp of the {@code SensorEvent} used to determine the offset
      * @return the offset in milliseconds
      */
-    private long eventTimeOffset(final SensorEvent event) {
+    long eventTimeOffset(final long eventTimeNanos) {
 
         // Capture timestamps of event reporting time
         final long elapsedRealTimeMillis = SystemClock.elapsedRealtime();
@@ -304,7 +304,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         // instead of the elapsedRealTime as the official documentation states for the `event.time`.
         // Once example could be the Nexus 4 according to https://stackoverflow.com/a/9333605/5815054,
         // but we also noticed this on some of our devices which we tested back in 2016/2017.
-        final long eventTimeMillis = event.timestamp / 1_000_000L;
+        final long eventTimeMillis = eventTimeNanos / 1_000_000L;
         final long elapsedTimeDiff = elapsedRealTimeMillis - eventTimeMillis;
         final long upTimeDiff = upTimeMillis - eventTimeMillis;
         final long currentTimeDiff = currentTimeMillis - eventTimeMillis;

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -37,6 +37,7 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.SystemClock;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -102,7 +103,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
      * Time offset used to move event time on devices measuring that time in milliseconds since device activation and
      * not Unix timestamp format. If event time is already in Unix timestamp format this should always be 0.
      */
-    private Long eventTimeOffset = null;
+    private Long eventTimeOffsetMillis = null;
     /**
      * Used for logging the time between sensor events. This is mainly used for debugging purposes.
      */
@@ -242,19 +243,11 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
      */
     @Override
     public synchronized void onSensorChanged(final @NonNull SensorEvent event) {
-        // The following block was moved before the setting of thisSensorEventTime without really knowing why it has
-        // been the other way around.
-        if (eventTimeOffset == null) {
-            // event.timestamp on Nexus5 with Android 6.0.1 seems to be the uptime in Nanoseconds (resets with
-            // rebooting)
-            // Attention: onSensorChanged might be called > 1 ms later than the actual event.
-            // Thus, the offset can be > 0 even on devices which use the system time as event time.
-            // This means we shift the sensor data (all together) slightly, execution time dependent
-            eventTimeOffset = System.currentTimeMillis() - event.timestamp / 1_000_000L;
-            Log.d(TAG, "onSensorChanged: eventTimeOffset initialized. Set to " + eventTimeOffset);
+        if (eventTimeOffsetMillis == null) {
+            eventTimeOffsetMillis = eventTimeOffset(event);
         }
-        Validate.notNull(eventTimeOffset);
-        long thisSensorEventTime = event.timestamp / 1_000_000L + eventTimeOffset;
+        Validate.notNull(eventTimeOffsetMillis);
+        long thisSensorEventTime = event.timestamp / 1_000_000L + eventTimeOffsetMillis;
 
         // Notify client about sensor update & bulkInsert data into database even without location fix
         if (!locationStatusHandler.hasLocationFix() && (lastNoGeoLocationFixUpdateTime == 0
@@ -284,6 +277,64 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         } else if (event.sensor.equals(sensorService.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD))) {
             saveSensorValue(event, directions);
         }
+    }
+
+    /**
+     * Calculates the static offset (ms) which needs to be added to the `event.time` (ns) in order
+     * to calculate the Unix timestamp of the event.
+     * <p>
+     * The official `SensorEvent#timestamp` documentation states the `event.time` the
+     * `SystemClock.elapsedRealTimeNanos()` at the time of capture. But we are taking into account that some
+     * manufacturers/devices use the nano-second equivalent of `SystemClock.currentTimeMillis()` instead.
+     * <p>
+     * As we only use `SystemClock` to calculate the offset (e.g. bootTime) this approach should
+     * allow to synchronize the event timestamps between phones by syncing their system time.
+     *
+     * @param event the {@code SensorEvent} to be used to determine the time offset
+     * @return the offset in milliseconds
+     */
+    private long eventTimeOffset(final SensorEvent event) {
+
+        // Capture timestamps of event reporting time
+        final long elapsedRealTimeMillis = SystemClock.elapsedRealtime();
+        final long upTimeMillis = SystemClock.uptimeMillis();
+        final long currentTimeMillis = System.currentTimeMillis();
+
+        // Check which timestamp the event.time is closest to, because some manufacturers and models use the currentTime
+        // instead of the elapsedRealTime as the official documentation states for the `event.time`.
+        // Once example could be the Nexus 4 according to https://stackoverflow.com/a/9333605/5815054,
+        // but we also noticed this on some of our devices which we tested back in 2016/2017.
+        final long eventTimeMillis = event.timestamp / 1_000_000L;
+        final long elapsedTimeDiff = elapsedRealTimeMillis - eventTimeMillis;
+        final long upTimeDiff = upTimeMillis - eventTimeMillis;
+        final long currentTimeDiff = currentTimeMillis - eventTimeMillis;
+        if (Math.min(Math.abs(currentTimeDiff), Math.abs(elapsedTimeDiff)) >= 1_000) {
+            // Not really a problem but could indicate there is another case we did not think of
+            Log.w(TAG,
+                    "sensorTimeOffset: event delay seems to be relatively high: " + currentTimeDiff + " ms");
+        }
+
+        // Default case (elapsedRealTime, following the documentation)
+        if (Math.abs(elapsedTimeDiff) <= Math.min(Math.abs(upTimeDiff), Math.abs(currentTimeDiff))) {
+            final long bootTimeMillis = currentTimeMillis - elapsedRealTimeMillis;
+            Log.d(TAG, "sensorTimeOffset: event.time seems to be elapsedTime, setting offset "
+                    + "to bootTime: " + bootTimeMillis + " ms");
+            return bootTimeMillis;
+        }
+        // Other seen case (currentTime, e.g. Nexus 4)
+        if (Math.abs(currentTimeDiff) <= Math.abs(upTimeDiff)) {
+            Log.d(TAG, "sensorTimeOffset: event.time seems to be currentTime, setting offset "
+                    + "to zero ms");
+            return 0;
+        }
+        // Possible case, but unknown if actually used by manufacturers (upTime)
+        // If we calculate a static offset between currentTime and upTime this would lead to time
+        // shifts when the device is in (deep) sleep again. We would need to calculate the offset
+        // dynamically for each event which is quite heavy. Thus, we throw an exception to see
+        // in the Play Store if this actually happens on devices. If so, this could be tested using:
+        // https://developer.android.com/training/monitoring-device-state/doze-standby#testing_doze_and_app_standby
+        throw new IllegalStateException("The event.time seems to be upTime. In this case we cannot"
+                + " use a static offset to calculate the Unix timestamp of the event");
     }
 
     /**
@@ -333,7 +384,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
      */
     private void saveSensorValue(final SensorEvent event, final List<Point3d> storage) {
         Point3d dataPoint = new Point3d(event.values[0], event.values[1], event.values[2],
-                event.timestamp / 1000000L + eventTimeOffset);
+                event.timestamp / 1_000_000L + eventTimeOffsetMillis);
         storage.add(dataPoint);
     }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -34,7 +34,6 @@ import android.hardware.SensorManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -267,9 +266,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
                 rotations.clear();
                 directions.clear();
                 lastNoGeoLocationFixUpdateTime = thisSensorEventTime;
-            } catch (SecurityException e) {
-                throw new IllegalStateException(e);
-            } catch (DataCapturingException e) {
+            } catch (SecurityException | DataCapturingException e) {
                 throw new IllegalStateException(e);
             }
         }
@@ -319,13 +316,8 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         locationManager.removeUpdates(this);
         locationStatusHandler.shutdown();
         sensorService.unregisterListener(this);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            sensorEventHandlerThread.quitSafely();
-            locationEventHandlerThread.quitSafely();
-        } else {
-            sensorEventHandlerThread.quit();
-            locationEventHandlerThread.quit();
-        }
+        sensorEventHandlerThread.quitSafely();
+        locationEventHandlerThread.quitSafely();
     }
 
     /**

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -246,7 +246,6 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         if (eventTimeOffsetMillis == null) {
             eventTimeOffsetMillis = eventTimeOffset(event.timestamp);
         }
-        Validate.notNull(eventTimeOffsetMillis);
         long thisSensorEventTime = event.timestamp / 1_000_000L + eventTimeOffsetMillis;
 
         // Notify client about sensor update & bulkInsert data into database even without location fix

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -103,7 +103,7 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
      * Time offset used to move event time on devices measuring that time in milliseconds since device activation and
      * not Unix timestamp format. If event time is already in Unix timestamp format this should always be 0.
      */
-    private long eventTimeOffset = 0;
+    private Long eventTimeOffset = null;
     /**
      * Used for logging the time between sensor events. This is mainly used for debugging purposes.
      */
@@ -245,11 +245,13 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
     public synchronized void onSensorChanged(final @NonNull SensorEvent event) {
         // The following block was moved before the setting of thisSensorEventTime without really knowing why it has
         // been the other way around.
-        if (eventTimeOffset == 0) {
+        if (eventTimeOffset == null) {
             // event.timestamp on Nexus5 with Android 6.0.1 seems to be the uptime in Nanoseconds (resets with
             // rebooting)
             eventTimeOffset = System.currentTimeMillis() - event.timestamp / 1_000_000L;
+            Log.d(TAG, "onSensorChanged: eventTimeOffset initialized. Set to " + eventTimeOffset);
         }
+        Validate.notNull(eventTimeOffset);
         long thisSensorEventTime = event.timestamp / 1_000_000L + eventTimeOffset;
 
         // Notify client about sensor update & bulkInsert data into database even without location fix

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -247,6 +247,9 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         if (eventTimeOffset == null) {
             // event.timestamp on Nexus5 with Android 6.0.1 seems to be the uptime in Nanoseconds (resets with
             // rebooting)
+            // Attention: onSensorChanged might be called > 1 ms later than the actual event.
+            // Thus, the offset can be > 0 even on devices which use the system time as event time.
+            // This means we shift the sensor data (all together) slightly, execution time dependent
             eventTimeOffset = System.currentTimeMillis() - event.timestamp / 1_000_000L;
             Log.d(TAG, "onSensorChanged: eventTimeOffset initialized. Set to " + eventTimeOffset);
         }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/CapturingProcess.java
@@ -34,6 +34,7 @@ import android.hardware.SensorManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -261,7 +262,9 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
                 rotations.clear();
                 directions.clear();
                 lastNoGeoLocationFixUpdateTime = thisSensorEventTime;
-            } catch (SecurityException | DataCapturingException e) {
+            } catch (SecurityException e) {
+                throw new IllegalStateException(e);
+            } catch (DataCapturingException e) {
                 throw new IllegalStateException(e);
             }
         }
@@ -369,8 +372,13 @@ public abstract class CapturingProcess implements SensorEventListener, LocationL
         locationManager.removeUpdates(this);
         locationStatusHandler.shutdown();
         sensorService.unregisterListener(this);
-        sensorEventHandlerThread.quitSafely();
-        locationEventHandlerThread.quitSafely();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            sensorEventHandlerThread.quitSafely();
+            locationEventHandlerThread.quitSafely();
+        } else {
+            sensorEventHandlerThread.quit();
+            locationEventHandlerThread.quit();
+        }
     }
 
     /**


### PR DESCRIPTION
While checking the code to see if we could synchronize the sensor-data of multiple devices by synchronizing the System clocks I noticed, that the `sensorTimeOffset` could theoretically be reset and lead to time-shifts in the data if:
* the first `sensorTimeOffset` calculation is `0` ms
* then the code would recalculate the offset until the offset is `!= 0`

This is why I'm using `Long` instead of `long` for the offset.
I say "theoretically" because the delay between the `event` and the `onSensorChanged` call was between 2 and 9 ms on our reference device. Thus, it might never be `0 ms` on real devices.

----------

In order to synchronize the sensor data we need to make sure the delay between the first `event` and it's `onSensorChanged(event)` call does not influence the `eventTimeOffsetMillis` and, thus, shift the sensor data a few milliseconds depending on the device.

To do this we're now only using the `SystemClock` to calculate the `eventTimeOffsetMillis` in the documented case where the `event.time` is the `elapsedRealTimeNanos` (which is the time since boot including the (deep) sleep time).

For the few devices where the `event.time` is the `currentTimeNanos` we're using an offset of `0` which should explain itself.