### PR TITLE
Task/vic 194 throw host unresolvable instead of sync error

### DIFF
--- a/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
+++ b/synchronization/src/androidTestCyface/java/de/cyface/synchronization/MockedHttpConnection.java
@@ -48,18 +48,18 @@ final class MockedHttpConnection implements Http {
     @NonNull
     @Override
     public HttpURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext,
-            boolean hasBinaryContent, @NonNull String jwtBearer) throws ServerUnavailableException {
+            boolean hasBinaryContent, @NonNull String jwtBearer) throws SynchronisationException {
         return openHttpConnection(url, sslContext, hasBinaryContent);
     }
 
     @NonNull
     @Override
     public HttpURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext,
-            boolean hasBinaryContent) throws ServerUnavailableException {
+            boolean hasBinaryContent) throws SynchronisationException {
         try {
             return (HttpURLConnection)url.openConnection();
         } catch (IOException e) {
-            throw new ServerUnavailableException("Mocked Err", e);
+            throw new SynchronisationException("Mocked Err", e);
         }
     }
 

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
@@ -70,6 +70,7 @@ import de.cyface.persistence.model.Track;
 import de.cyface.persistence.serialization.EventsFileSerializerStrategy;
 import de.cyface.persistence.serialization.MeasurementFileSerializerStrategy;
 import de.cyface.persistence.serialization.MeasurementSerializer;
+import de.cyface.synchronization.exception.HostUnresolvable;
 import de.cyface.utils.CursorIsNullException;
 import de.cyface.utils.Validate;
 
@@ -125,9 +126,9 @@ public class SyncPerformerTest {
      */
     @Test
     public void testSendData_returnsTrueWhenServerReturns409() throws CursorIsNullException, NoSuchMeasurementException,
-            ServerUnavailableException, ForbiddenException, BadRequestException, ConflictException,
-            UnauthorizedException, InternalServerErrorException, EntityNotParsableException, SynchronisationException,
-            NetworkUnavailableException, SynchronizationInterruptedException, TooManyRequestsException {
+      ServerUnavailableException, ForbiddenException, BadRequestException, ConflictException,
+      UnauthorizedException, InternalServerErrorException, EntityNotParsableException, SynchronisationException,
+      NetworkUnavailableException, SynchronizationInterruptedException, TooManyRequestsException, HostUnresolvable {
 
         // Arrange
         // Insert data to be synced

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -150,6 +150,8 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
         } catch (final SynchronisationException e) {
             throw new IllegalStateException(e);
         }
+        // Due to the interface we can only throw NetworkErrorException
+        // Thus, we report the specific error type via sendErrorIntent()
         try {
             freshAuthToken = login(account.name, password, sslContext);
         } catch (final ServerUnavailableException | ForbiddenException e) {

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -19,6 +19,7 @@
 package de.cyface.synchronization;
 
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.HOST_UNRESOLVABLE;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.MALFORMED_URL;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.NETWORK_UNAVAILABLE;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.SERVER_UNAVAILABLE;
@@ -60,6 +61,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import de.cyface.synchronization.exception.HostUnresolvable;
 
 /**
  * The CyfaceAuthenticator is called by the {@link AccountManager} to fulfill all account relevant
@@ -149,7 +152,7 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
         }
         try {
             freshAuthToken = login(account.name, password, sslContext);
-        } catch (final ServerUnavailableException e) {
+        } catch (final ServerUnavailableException | ForbiddenException e) {
             sendErrorIntent(context, SERVER_UNAVAILABLE.getCode(), e.getMessage());
             throw new NetworkErrorException(e);
         } catch (final MalformedURLException e) {
@@ -166,6 +169,9 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
             throw new NetworkErrorException(e);
         } catch (final TooManyRequestsException e) {
             sendErrorIntent(context, TOO_MANY_REQUESTS.getCode(), e.getMessage());
+            throw new NetworkErrorException(e);
+        } catch (final HostUnresolvable e) {
+            sendErrorIntent(context, HOST_UNRESOLVABLE.getCode(), e.getMessage());
             throw new NetworkErrorException(e);
         }
 
@@ -284,10 +290,11 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
      * @throws ServerUnavailableException When there seems to be no server at the given URL.
      * @throws NetworkUnavailableException When the network used for transmission becomes unavailable.
      * @throws TooManyRequestsException When the server returns {@link HttpConnection#HTTP_TOO_MANY_REQUESTS}
+     * @throws ForbiddenException E.g. when there is no actual API running at the URL
      */
     private String login(final @NonNull String username, final @NonNull String password, SSLContext sslContext)
             throws ServerUnavailableException, MalformedURLException, SynchronisationException, UnauthorizedException,
-            NetworkUnavailableException, TooManyRequestsException {
+            NetworkUnavailableException, TooManyRequestsException, HostUnresolvable, ForbiddenException {
         Log.v(TAG, "Logging in to get new authToken");
 
         // Load authUrl
@@ -319,8 +326,8 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
             final HttpResponse loginResponse;
             try {
                 loginResponse = http.post(connection, loginPayload, false);
-            } catch (final BadRequestException | InternalServerErrorException | ForbiddenException
-                    | EntityNotParsableException | ConflictException e) {
+            } catch (final BadRequestException | InternalServerErrorException | EntityNotParsableException
+                    | ConflictException e) {
                 throw new IllegalStateException(e); // API definition does not define those errors
             }
 

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -284,7 +284,8 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
      *            logging in to the Cyface server.
      * @param sslContext To open a SSL connection
      * @return The currently valid auth token to be used by further requests from this application.
-     * @throws SynchronisationException – If an IOException occurred while reading the response code.
+     * @throws SynchronisationException If an IOException occurred while reading the response code or the connection
+     *             could not be prepared
      * @throws UnauthorizedException When the server returns {@code HttpURLConnection#HTTP_UNAUTHORIZED}
      * @throws MalformedURLException If no protocol is specified, or an unknown protocol is found, or spec is null.
      * @throws ServerUnavailableException When there seems to be no server at the given URL.

--- a/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
@@ -122,7 +122,7 @@ public class ErrorHandler extends BroadcastReceiver {
                 break;
 
             case MALFORMED_URL:
-                errorMessage = context.getString(de.cyface.synchronization.R.string.error_message_server_unavailable);
+                errorMessage = context.getString(R.string.error_message_url_unreadable);
                 break;
 
             case UNREADABLE_HTTP_RESPONSE:

--- a/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
@@ -101,8 +101,9 @@ public class ErrorHandler extends BroadcastReceiver {
         final Intent intent = new Intent(ERROR_INTENT);
         intent.putExtra(ERROR_CODE_EXTRA, errorCode);
         LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
-        Log.d(TAG, message);
-        // Log.d(TAG, (message != null && message.length() > 0 ? message : "no error message provide"));
+        if (message != null) {
+            Log.d(TAG, message);
+        }
     }
 
     @Override

--- a/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
@@ -198,6 +198,10 @@ public class ErrorHandler extends BroadcastReceiver {
                 errorMessage = context.getString(R.string.error_message_too_many_requests);
                 break;
 
+            case HOST_UNRESOLVABLE:
+                errorMessage = context.getString(R.string.error_message_host_unresolvable);
+                break;
+
             default:
                 errorMessage = context.getString(de.cyface.synchronization.R.string.error_message_unknown_error);
         }
@@ -222,7 +226,8 @@ public class ErrorHandler extends BroadcastReceiver {
                                 11), BAD_REQUEST(12), FORBIDDEN(13), INTERNAL_SERVER_ERROR(
                                         14), ENTITY_NOT_PARSABLE(
                                                 15), NETWORK_UNAVAILABLE(
-                                                        16), SYNCHRONIZATION_INTERRUPTED(17), TOO_MANY_REQUESTS(18);
+                                                        16), SYNCHRONIZATION_INTERRUPTED(
+                                                                17), TOO_MANY_REQUESTS(18), HOST_UNRESOLVABLE(19);
         // MEASUREMENT_ENTRY_IS_IRRETRIEVABLE(X),
 
         private final int code;

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -27,6 +27,8 @@ import org.json.JSONObject;
 
 import androidx.annotation.NonNull;
 
+import de.cyface.synchronization.exception.HostUnresolvable;
+
 /**
  * An interface for http connections.
  *
@@ -98,13 +100,15 @@ interface Http {
      * @throws InternalServerErrorException When the server returns {@code HttpURLConnection#HTTP_INTERNAL_ERROR}
      * @throws NetworkUnavailableException When the network used for transmission becomes unavailable.
      * @throws TooManyRequestsException When the server returns {@link HttpConnection#HTTP_TOO_MANY_REQUESTS}
+     * @throws HostUnresolvable e.g. when the phone is connected to a network which is not connected to the internet
+     * @throws ServerUnavailableException When no connection could be established with the server
      */
     @NonNull
     HttpResponse post(@NonNull final HttpURLConnection connection, @NonNull final JSONObject payload,
             final boolean compress)
             throws SynchronisationException, UnauthorizedException, BadRequestException, InternalServerErrorException,
             ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
-            TooManyRequestsException;
+            TooManyRequestsException, HostUnresolvable, ServerUnavailableException;
 
     /**
      * The serialized post request which transmits a measurement through an existing http connection
@@ -125,6 +129,8 @@ interface Http {
      * @throws SynchronizationInterruptedException When the transmission stream ended too early, likely because the sync
      *             thread was interrupted (sync canceled)
      * @throws TooManyRequestsException When the server returns {@link HttpConnection#HTTP_TOO_MANY_REQUESTS}
+     * @throws HostUnresolvable e.g. when the phone is connected to a network which is not connected to the internet
+     * @throws ServerUnavailableException When no connection could be established with the server
      */
     @SuppressWarnings("UnusedReturnValue") // May be used in the future
     @NonNull
@@ -132,5 +138,5 @@ interface Http {
             @NonNull final UploadProgressListener progressListener, @NonNull FilePart... files)
             throws SynchronisationException, BadRequestException, UnauthorizedException, InternalServerErrorException,
             ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
-            SynchronizationInterruptedException, TooManyRequestsException;
+            SynchronizationInterruptedException, TooManyRequestsException, HostUnresolvable, ServerUnavailableException;
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -65,11 +65,11 @@ interface Http {
      * @param hasBinaryContent True if binary content is to be transmitted
      * @param jwtBearer A String in the format "Bearer TOKEN".
      * @return the HTTPURLConnection
-     * @throws ServerUnavailableException When there seems to be no server at the given URL.
+     * @throws SynchronisationException When the connection object could not be prepared
      */
     @NonNull
     HttpURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext, boolean hasBinaryContent,
-            @NonNull String jwtBearer) throws ServerUnavailableException;
+            @NonNull String jwtBearer) throws SynchronisationException;
 
     /**
      * A HTTPConnection must be opened with the right header before you can communicate with the Cyface REST API
@@ -78,11 +78,11 @@ interface Http {
      * @param sslContext The {@link SSLContext} to open a secure connection to the server
      * @param hasBinaryContent True if binary content is to be transmitted
      * @return the HTTPURLConnection
-     * @throws ServerUnavailableException When there seems to be no server at the given URL.
+     * @throws SynchronisationException When the connection object could not be prepared
      */
     @NonNull
     HttpURLConnection openHttpConnection(@NonNull URL url, @NonNull SSLContext sslContext, boolean hasBinaryContent)
-            throws ServerUnavailableException;
+            throws SynchronisationException;
 
     /**
      * The compressed post request which transmits a measurement batch through an existing http

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -90,7 +90,7 @@ public class HttpConnection implements Http {
     @NonNull
     @Override
     public HttpURLConnection openHttpConnection(@NonNull final URL url, @NonNull final SSLContext sslContext,
-            final boolean hasBinaryContent, final @NonNull String jwtToken) throws ServerUnavailableException {
+            final boolean hasBinaryContent, final @NonNull String jwtToken) throws SynchronisationException {
         final HttpURLConnection connection = openHttpConnection(url, sslContext, hasBinaryContent);
         connection.setRequestProperty("Authorization", "Bearer " + jwtToken);
         return connection;
@@ -99,13 +99,14 @@ public class HttpConnection implements Http {
     @NonNull
     @Override
     public HttpURLConnection openHttpConnection(@NonNull final URL url, @NonNull final SSLContext sslContext,
-            final boolean hasBinaryContent) throws ServerUnavailableException {
+            final boolean hasBinaryContent) throws SynchronisationException {
         HttpURLConnection connection;
         try {
             connection = (HttpURLConnection)url.openConnection();
         } catch (final IOException e) {
-            throw new ServerUnavailableException(
-                    String.format("Error %s. There seems to be no server at %s.", e.getMessage(), url.toString()), e);
+            // openConnection() only prepares, but does not establish an actual network connection
+            throw new SynchronisationException(String.format("Error %s. Unable to prepare connection for URL  %s.",
+                    e.getMessage(), url.toString()), e);
         }
 
         if (url.getPath().startsWith("https://")) {

--- a/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/HttpConnection.java
@@ -162,7 +162,8 @@ public class HttpConnection implements Http {
             outputStream.close();
         } catch (final SSLException e) {
             // This exception is thrown by OkHttp when the network is no longer available
-            if (e.getMessage().contains("I/O error during system call, Broken pipe")) {
+            final String message = e.getMessage();
+            if (message != null && message.contains("I/O error during system call, Broken pipe")) {
                 Log.w(TAG, "Caught SSLException: " + e.getMessage());
                 throw new NetworkUnavailableException("Network became unavailable during transmission.", e);
             } else {
@@ -233,7 +234,8 @@ public class HttpConnection implements Http {
         } catch (final SSLException e) {
             Log.w(TAG, "Caught SSLException: " + e.getMessage());
             // This exception is thrown by OkHttp when the network is no longer available
-            if (e.getMessage().contains("I/O error during system call, Broken pipe")) {
+            final String message = e.getMessage();
+            if (message != null && message.contains("I/O error during system call, Broken pipe")) {
                 throw new NetworkUnavailableException("Network became unavailable during transmission.");
             }
             throw new SynchronisationException(e); // SSLException with unknown cause MOV-774
@@ -243,7 +245,8 @@ public class HttpConnection implements Http {
         } catch (final IOException e) {
             Log.w(TAG, "Caught IOException: " + e.getMessage());
             // Logging out interrupts the sync thread. This must not throw a RuntimeException, thus:
-            if (e.getMessage().contains("unexpected end of stream")) {
+            final String message = e.getMessage();
+            if (message != null && message.contains("unexpected end of stream")) {
                 throw new SynchronizationInterruptedException("Sync was probably interrupted via cancelSynchronization",
                         e);
             }

--- a/synchronization/src/main/java/de/cyface/synchronization/ServerUnavailableException.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/ServerUnavailableException.java
@@ -21,6 +21,13 @@ public class ServerUnavailableException extends Exception {
      * @param cause The <code>Exception</code> that caused this one.
      */
     public ServerUnavailableException(final String detailedMessage, final Exception cause) {
-        super(detailedMessage,cause);
+        super(detailedMessage, cause);
+    }
+
+    /**
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public ServerUnavailableException(final Exception cause) {
+        super(cause);
     }
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -20,7 +20,6 @@ package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.AUTH_TOKEN_TYPE;
 import static de.cyface.synchronization.Constants.TAG;
-import static de.cyface.synchronization.ErrorHandler.ErrorCode.NETWORK_ERROR;
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.AUTHENTICATION_ERROR;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.DATABASE_ERROR;
@@ -230,7 +229,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
         } catch (final NetworkErrorException e) {
             Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
             syncResult.stats.numIoExceptions++;
-            sendErrorIntent(context, NETWORK_ERROR.getCode(), e.getMessage());
+            // No need to sendErrorIntent() as CyfaceAuthenticator already throws more specific error
         } finally {
             Log.d(TAG, String.format("Sync finished. (%s)", syncResult.hasError() ? "ERROR" : "success"));
             for (final ConnectionStatusListener listener : progressListener) {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncAdapter.java
@@ -20,6 +20,7 @@ package de.cyface.synchronization;
 
 import static de.cyface.synchronization.Constants.AUTH_TOKEN_TYPE;
 import static de.cyface.synchronization.Constants.TAG;
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.NETWORK_ERROR;
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.AUTHENTICATION_ERROR;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.DATABASE_ERROR;
@@ -229,7 +230,7 @@ public final class SyncAdapter extends AbstractThreadedSyncAdapter {
         } catch (final NetworkErrorException e) {
             Log.w(TAG, e.getClass().getSimpleName() + ": " + e.getMessage());
             syncResult.stats.numIoExceptions++;
-            sendErrorIntent(context, SYNCHRONIZATION_INTERRUPTED.getCode(), e.getMessage());
+            sendErrorIntent(context, NETWORK_ERROR.getCode(), e.getMessage());
         } finally {
             Log.d(TAG, String.format("Sync finished. (%s)", syncResult.hasError() ? "ERROR" : "success"));
             for (final ConnectionStatusListener listener : progressListener) {

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
@@ -24,6 +24,7 @@ import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.BAD_REQUEST;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.ENTITY_NOT_PARSABLE;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.FORBIDDEN;
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.HOST_UNRESOLVABLE;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.INTERNAL_SERVER_ERROR;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.MALFORMED_URL;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.NETWORK_UNAVAILABLE;
@@ -52,6 +53,7 @@ import de.cyface.persistence.Constants;
 import de.cyface.persistence.DefaultFileAccess;
 import de.cyface.persistence.model.Event;
 import de.cyface.persistence.model.Measurement;
+import de.cyface.synchronization.exception.HostUnresolvable;
 
 /**
  * Performs the actual synchronisation with a provided server, by uploading meta data and a file containing
@@ -187,6 +189,10 @@ class SyncPerformer {
         } catch (final TooManyRequestsException e) {
             syncResult.stats.numIoExceptions++;
             sendErrorIntent(context, TOO_MANY_REQUESTS.getCode(), e.getMessage());
+            return false;
+        } catch (final HostUnresolvable e) {
+            syncResult.stats.numIoExceptions++;
+            sendErrorIntent(context, HOST_UNRESOLVABLE.getCode(), e.getMessage());
             return false;
         } catch (final ConflictException e) {
             syncResult.stats.numSkippedEntries++;

--- a/synchronization/src/main/java/de/cyface/synchronization/exception/HostUnresolvable.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/exception/HostUnresolvable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Cyface GmbH
+ *
+ * This file is part of the Cyface SDK for Android.
+ *
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.synchronization.exception;
+
+/**
+ * An {@code Exception} thrown when the host of the Cyface server cannot be resolved.
+ * <p>
+ * This is e.g. the case when the phone is connected to a Wi-Fi which is not connected to the internet.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 6.1.0-beta1
+ */
+public class HostUnresolvable extends Exception {
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
+     */
+    public HostUnresolvable(final String detailedMessage) {
+        super(detailedMessage);
+    }
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public HostUnresolvable(final String detailedMessage, final Exception cause) {
+        super(detailedMessage, cause);
+    }
+
+    /**
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public HostUnresolvable(final Exception cause) {
+        super(cause);
+    }
+}

--- a/synchronization/src/main/res/values-de/strings.xml
+++ b/synchronization/src/main/res/values-de/strings.xml
@@ -25,6 +25,7 @@
     <string name="error_message_network_unavailable">Verbindungsabbruch</string>
     <string name="error_message_synchronization_interrupted">Synchronisierung unterbrochen</string>
     <string name="error_message_too_many_requests">Zu viele Anfragen</string>
+    <string name="error_message_host_unresolvable">Server unauffindbar. Bitte Internet-Verbindung prüfen.</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unerwarteter Fehler</string>

--- a/synchronization/src/main/res/values-it/strings.xml
+++ b/synchronization/src/main/res/values-it/strings.xml
@@ -25,6 +25,7 @@
     <string name="error_message_network_unavailable">Connessione interrotta</string>
     <string name="error_message_synchronization_interrupted">Sincronizzazione interrotta</string>
     <string name="error_message_too_many_requests">Troppe richieste</string>
+    <string name="error_message_host_unresolvable">Impossibile trovare il server. Si prega di controllare la connessione internet.</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Errore imprevisto</string>

--- a/synchronization/src/main/res/values/strings.xml
+++ b/synchronization/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="error_message_network_unavailable">Connection interrupted</string>
     <string name="error_message_synchronization_interrupted">Synchronization interrupted</string>
     <string name="error_message_too_many_requests">Too many requests</string>
+    <string name="error_message_host_unresolvable">Cannot find server. Please check your internet connection.</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unexpected error</string>


### PR DESCRIPTION
This PR fixes:

1) Forbidden throws hard exception
E.g. when no API is running under the server address the server can return "Forbidden".
We now catch the exception softly and only inform the error handler about this so that it can show a message to the user (depending on the SDK-integrating app).

2) We now throw a more specific HostUnresolvable exception when the Hostname is not resolvable.
This happens e.g. when the user is in a network which is offline.
Before we did throw a very unspecific SynchronizationException.

3) We now throw a more specific ServerUnreachable exception when no connection could be established with the server.
This can be the case e.g. when there are problems with the SSL certificate.
Before we did throw a very unspecific SynchronizationException.

4) When the synchronization experienced an error, two error messages were sent to the error handlers.
This caused two error messages shown in the SDK implementing app (CY).
This was fixed.

These are API breaking changes so they are released as Beta version and only integrated by us for now.