### PR TITLE
Task/dat 965 support registration

### DIFF
--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
@@ -66,6 +66,7 @@ import de.cyface.persistence.model.MeasurementStatus;
 import de.cyface.persistence.model.Modality;
 import de.cyface.persistence.model.Track;
 import de.cyface.persistence.serialization.MeasurementSerializer;
+import de.cyface.synchronization.exception.AccountNotActivated;
 import de.cyface.synchronization.exception.BadRequestException;
 import de.cyface.synchronization.exception.ConflictException;
 import de.cyface.synchronization.exception.EntityNotParsableException;
@@ -79,6 +80,7 @@ import de.cyface.synchronization.exception.SynchronisationException;
 import de.cyface.synchronization.exception.SynchronizationInterruptedException;
 import de.cyface.synchronization.exception.TooManyRequestsException;
 import de.cyface.synchronization.exception.UnauthorizedException;
+import de.cyface.synchronization.exception.UnexpectedResponseCode;
 import de.cyface.synchronization.exception.UploadSessionExpired;
 import de.cyface.utils.CursorIsNullException;
 import de.cyface.utils.Validate;
@@ -136,7 +138,7 @@ public class SyncPerformerTest {
             ServerUnavailableException, ForbiddenException, BadRequestException, ConflictException,
             UnauthorizedException, InternalServerErrorException, EntityNotParsableException, SynchronisationException,
             NetworkUnavailableException, SynchronizationInterruptedException, TooManyRequestsException,
-            HostUnresolvable, MeasurementTooLarge, UploadSessionExpired {
+            HostUnresolvable, MeasurementTooLarge, UploadSessionExpired, UnexpectedResponseCode, AccountNotActivated {
 
         // Arrange
         // Insert data to be synced
@@ -216,7 +218,7 @@ public class SyncPerformerTest {
             BadRequestException, EntityNotParsableException, ForbiddenException, ConflictException,
             NetworkUnavailableException, SynchronizationInterruptedException, InternalServerErrorException,
             SynchronisationException, UnauthorizedException, TooManyRequestsException, HostUnresolvable,
-            ServerUnavailableException, MeasurementTooLarge, UploadSessionExpired {
+            ServerUnavailableException, MeasurementTooLarge, UploadSessionExpired, UnexpectedResponseCode, AccountNotActivated {
 
         // Arrange
         // 24 hours test data ~ 108 MB which is more then the currently supported upload size (100)

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -18,6 +18,7 @@
  */
 package de.cyface.synchronization;
 
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.ACCOUNT_NOT_ACTIVATED;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.UNEXPECTED_RESPONSE_CODE;
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.HOST_UNRESOLVABLE;
@@ -51,6 +52,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import de.cyface.synchronization.exception.AccountNotActivated;
 import de.cyface.synchronization.exception.BadRequestException;
 import de.cyface.synchronization.exception.ConflictException;
 import de.cyface.synchronization.exception.EntityNotParsableException;
@@ -170,6 +172,9 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
         } catch (final UnexpectedResponseCode e) {
             sendErrorIntent(context, UNEXPECTED_RESPONSE_CODE.getCode(), e.getMessage());
             throw new NetworkErrorException(e);
+        } catch (final AccountNotActivated e) {
+            sendErrorIntent(context, ACCOUNT_NOT_ACTIVATED.getCode(), e.getMessage());
+            throw new NetworkErrorException(e);
         }
 
         // Return a bundle containing the token
@@ -242,10 +247,11 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
      * @throws TooManyRequestsException When the server returns {@link HttpConnection#HTTP_TOO_MANY_REQUESTS}
      * @throws ForbiddenException E.g. when there is no actual API running at the URL
      * @throws UnexpectedResponseCode When the server returns an unexpected response code
+     * @throws AccountNotActivated When the user account is not activated
      */
     private String login(final @NonNull String username, final @NonNull String password)
             throws ServerUnavailableException, MalformedURLException, SynchronisationException, UnauthorizedException,
-            NetworkUnavailableException, TooManyRequestsException, HostUnresolvable, ForbiddenException, UnexpectedResponseCode {
+            NetworkUnavailableException, TooManyRequestsException, HostUnresolvable, ForbiddenException, UnexpectedResponseCode, AccountNotActivated {
         Log.v(TAG, "Logging in to get new authToken");
 
         // Load authUrl

--- a/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
+++ b/synchronization/src/cyface/java/de/cyface/synchronization/CyfaceAuthenticator.java
@@ -18,6 +18,7 @@
  */
 package de.cyface.synchronization;
 
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.UNEXPECTED_RESPONSE_CODE;
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.HOST_UNRESOLVABLE;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.MALFORMED_URL;
@@ -61,6 +62,7 @@ import de.cyface.synchronization.exception.ServerUnavailableException;
 import de.cyface.synchronization.exception.SynchronisationException;
 import de.cyface.synchronization.exception.TooManyRequestsException;
 import de.cyface.synchronization.exception.UnauthorizedException;
+import de.cyface.synchronization.exception.UnexpectedResponseCode;
 
 /**
  * The CyfaceAuthenticator is called by the {@link AccountManager} to fulfill all account relevant
@@ -73,7 +75,7 @@ import de.cyface.synchronization.exception.UnauthorizedException;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 3.0.0
+ * @version 3.1.0
  * @since 2.0.0
  */
 public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
@@ -165,6 +167,9 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
         } catch (final HostUnresolvable e) {
             sendErrorIntent(context, HOST_UNRESOLVABLE.getCode(), e.getMessage());
             throw new NetworkErrorException(e);
+        } catch (final UnexpectedResponseCode e) {
+            sendErrorIntent(context, UNEXPECTED_RESPONSE_CODE.getCode(), e.getMessage());
+            throw new NetworkErrorException(e);
         }
 
         // Return a bundle containing the token
@@ -236,10 +241,11 @@ public final class CyfaceAuthenticator extends AbstractAccountAuthenticator {
      * @throws NetworkUnavailableException When the network used for transmission becomes unavailable.
      * @throws TooManyRequestsException When the server returns {@link HttpConnection#HTTP_TOO_MANY_REQUESTS}
      * @throws ForbiddenException E.g. when there is no actual API running at the URL
+     * @throws UnexpectedResponseCode When the server returns an unexpected response code
      */
     private String login(final @NonNull String username, final @NonNull String password)
             throws ServerUnavailableException, MalformedURLException, SynchronisationException, UnauthorizedException,
-            NetworkUnavailableException, TooManyRequestsException, HostUnresolvable, ForbiddenException {
+            NetworkUnavailableException, TooManyRequestsException, HostUnresolvable, ForbiddenException, UnexpectedResponseCode {
         Log.v(TAG, "Logging in to get new authToken");
 
         // Load authUrl

--- a/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Cyface GmbH
+ * Copyright 2018-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -41,7 +41,7 @@ import de.cyface.utils.Validate;
  * support time for all involved.
  *
  * @author Armin Schnabel
- * @version 2.0.1
+ * @version 2.1.0
  * @since 2.2.0
  */
 public class ErrorHandler extends BroadcastReceiver {
@@ -207,6 +207,10 @@ public class ErrorHandler extends BroadcastReceiver {
                 errorMessage = context.getString(R.string.error_message_upload_session_expired);
                 break;
 
+            case UNEXPECTED_RESPONSE_CODE:
+                errorMessage = context.getString(R.string.error_message_unexpected_response_code);
+                break;
+
             default:
                 errorMessage = context.getString(de.cyface.synchronization.R.string.error_message_unknown_error);
         }
@@ -220,19 +224,21 @@ public class ErrorHandler extends BroadcastReceiver {
      * A list of known Errors which are thrown by the Cyface SDK.
      *
      * @author Armin Schnabel
-     * @version 1.2.0
+     * @version 1.3.0
      * @since 1.0.0
      */
     public enum ErrorCode {
 
         UNKNOWN(0), UNAUTHORIZED(1), MALFORMED_URL(2), UNREADABLE_HTTP_RESPONSE(3), SERVER_UNAVAILABLE(
                 4), NETWORK_ERROR(5), DATABASE_ERROR(6), AUTHENTICATION_ERROR(7), AUTHENTICATION_CANCELED(
-                8), SYNCHRONIZATION_ERROR(9), DATA_TRANSMISSION_ERROR(10), SSL_CERTIFICATE_UNKNOWN(
-                11), BAD_REQUEST(12), FORBIDDEN(13), INTERNAL_SERVER_ERROR(
-                14), ENTITY_NOT_PARSABLE(
-                15), NETWORK_UNAVAILABLE(
-                16), SYNCHRONIZATION_INTERRUPTED(
-                17), TOO_MANY_REQUESTS(18), HOST_UNRESOLVABLE(19), UPLOAD_SESSION_EXPIRED(20);
+                        8), SYNCHRONIZATION_ERROR(9), DATA_TRANSMISSION_ERROR(10), SSL_CERTIFICATE_UNKNOWN(
+                                11), BAD_REQUEST(12), FORBIDDEN(13), INTERNAL_SERVER_ERROR(
+                                        14), ENTITY_NOT_PARSABLE(
+                                                15), NETWORK_UNAVAILABLE(
+                                                        16), SYNCHRONIZATION_INTERRUPTED(
+                                                                17), TOO_MANY_REQUESTS(18), HOST_UNRESOLVABLE(
+                                                                        19), UPLOAD_SESSION_EXPIRED(
+                                                                                20), UNEXPECTED_RESPONSE_CODE(21);
         // MEASUREMENT_ENTRY_IS_IRRETRIEVABLE(X),
 
         private final int code;

--- a/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.java
@@ -211,6 +211,10 @@ public class ErrorHandler extends BroadcastReceiver {
                 errorMessage = context.getString(R.string.error_message_unexpected_response_code);
                 break;
 
+            case ACCOUNT_NOT_ACTIVATED:
+                errorMessage = context.getString(R.string.error_message_account_not_activated);
+                break;
+
             default:
                 errorMessage = context.getString(de.cyface.synchronization.R.string.error_message_unknown_error);
         }
@@ -238,7 +242,7 @@ public class ErrorHandler extends BroadcastReceiver {
                                                         16), SYNCHRONIZATION_INTERRUPTED(
                                                                 17), TOO_MANY_REQUESTS(18), HOST_UNRESOLVABLE(
                                                                         19), UPLOAD_SESSION_EXPIRED(
-                                                                                20), UNEXPECTED_RESPONSE_CODE(21);
+                                                                                20), UNEXPECTED_RESPONSE_CODE(21), ACCOUNT_NOT_ACTIVATED(22);
         // MEASUREMENT_ENTRY_IS_IRRETRIEVABLE(X),
 
         private final int code;

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -27,6 +27,7 @@ import org.json.JSONObject;
 import androidx.annotation.NonNull;
 
 import de.cyface.model.RequestMetaData;
+import de.cyface.synchronization.exception.AccountNotActivated;
 import de.cyface.synchronization.exception.BadRequestException;
 import de.cyface.synchronization.exception.ConflictException;
 import de.cyface.synchronization.exception.EntityNotParsableException;
@@ -105,6 +106,7 @@ interface Http {
      * @throws HostUnresolvable e.g. when the phone is connected to a network which is not connected to the internet
      * @throws ServerUnavailableException When no connection could be established with the server
      * @throws UnexpectedResponseCode When the server returns an unexpected response code
+     * @throws AccountNotActivated When the user account is not activated
      * @return {@code HttpConnection.Result.LOGIN_SUCCESSFUL} if successful or else an {@code Exception}.
      */
     @NonNull
@@ -112,7 +114,7 @@ interface Http {
             final boolean compress)
             throws SynchronisationException, UnauthorizedException, BadRequestException, InternalServerErrorException,
             ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
-            TooManyRequestsException, HostUnresolvable, ServerUnavailableException, UnexpectedResponseCode;
+            TooManyRequestsException, HostUnresolvable, ServerUnavailableException, UnexpectedResponseCode, AccountNotActivated;
 
     /**
      * The serialized post request which transmits a measurement through an existing http connection
@@ -137,6 +139,7 @@ interface Http {
      * @throws ServerUnavailableException When no connection could be established with the server
      * @throws MeasurementTooLarge When the transfer file is too large to be uploaded.
      * @throws UnexpectedResponseCode When the server returns an unexpected response code
+     * @throws AccountNotActivated When the user account is not activated
      * @return {@code HttpConnection.Result.UPLOAD_SUCCESSFUL} on success, {@code HttpConnection.Result.UPLOAD_FAILED}
      *         when the upload attempt should be repeated or {@code HttpConnection.Result.UPLOAD_SKIPPED} if the server
      *         is not interested in the data.
@@ -146,5 +149,5 @@ interface Http {
             throws SynchronisationException, BadRequestException, UnauthorizedException, InternalServerErrorException,
             ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
             SynchronizationInterruptedException, TooManyRequestsException, HostUnresolvable, ServerUnavailableException,
-            MeasurementTooLarge, UploadSessionExpired, UnexpectedResponseCode;
+            MeasurementTooLarge, UploadSessionExpired, UnexpectedResponseCode, AccountNotActivated;
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/Http.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/Http.java
@@ -40,6 +40,7 @@ import de.cyface.synchronization.exception.SynchronisationException;
 import de.cyface.synchronization.exception.SynchronizationInterruptedException;
 import de.cyface.synchronization.exception.TooManyRequestsException;
 import de.cyface.synchronization.exception.UnauthorizedException;
+import de.cyface.synchronization.exception.UnexpectedResponseCode;
 import de.cyface.synchronization.exception.UploadSessionExpired;
 
 /**
@@ -47,7 +48,7 @@ import de.cyface.synchronization.exception.UploadSessionExpired;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 10.0.0
+ * @version 10.1.0
  * @since 3.0.0
  */
 interface Http {
@@ -103,6 +104,7 @@ interface Http {
      * @throws TooManyRequestsException When the server returns {@link HttpConnection#HTTP_TOO_MANY_REQUESTS}
      * @throws HostUnresolvable e.g. when the phone is connected to a network which is not connected to the internet
      * @throws ServerUnavailableException When no connection could be established with the server
+     * @throws UnexpectedResponseCode When the server returns an unexpected response code
      * @return {@code HttpConnection.Result.LOGIN_SUCCESSFUL} if successful or else an {@code Exception}.
      */
     @NonNull
@@ -110,7 +112,7 @@ interface Http {
             final boolean compress)
             throws SynchronisationException, UnauthorizedException, BadRequestException, InternalServerErrorException,
             ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
-            TooManyRequestsException, HostUnresolvable, ServerUnavailableException;
+            TooManyRequestsException, HostUnresolvable, ServerUnavailableException, UnexpectedResponseCode;
 
     /**
      * The serialized post request which transmits a measurement through an existing http connection
@@ -134,6 +136,7 @@ interface Http {
      * @throws HostUnresolvable e.g. when the phone is connected to a network which is not connected to the internet
      * @throws ServerUnavailableException When no connection could be established with the server
      * @throws MeasurementTooLarge When the transfer file is too large to be uploaded.
+     * @throws UnexpectedResponseCode When the server returns an unexpected response code
      * @return {@code HttpConnection.Result.UPLOAD_SUCCESSFUL} on success, {@code HttpConnection.Result.UPLOAD_FAILED}
      *         when the upload attempt should be repeated or {@code HttpConnection.Result.UPLOAD_SKIPPED} if the server
      *         is not interested in the data.
@@ -143,5 +146,5 @@ interface Http {
             throws SynchronisationException, BadRequestException, UnauthorizedException, InternalServerErrorException,
             ForbiddenException, EntityNotParsableException, ConflictException, NetworkUnavailableException,
             SynchronizationInterruptedException, TooManyRequestsException, HostUnresolvable, ServerUnavailableException,
-            MeasurementTooLarge, UploadSessionExpired;
+            MeasurementTooLarge, UploadSessionExpired, UnexpectedResponseCode;
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
@@ -19,6 +19,7 @@
 package de.cyface.synchronization;
 
 import static de.cyface.serializer.DataSerializable.humanReadableSize;
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.ACCOUNT_NOT_ACTIVATED;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.UNEXPECTED_RESPONSE_CODE;
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.BAD_REQUEST;
@@ -48,6 +49,7 @@ import androidx.annotation.NonNull;
 import de.cyface.model.RequestMetaData;
 import de.cyface.persistence.Constants;
 import de.cyface.persistence.model.Measurement;
+import de.cyface.synchronization.exception.AccountNotActivated;
 import de.cyface.synchronization.exception.BadRequestException;
 import de.cyface.synchronization.exception.ConflictException;
 import de.cyface.synchronization.exception.EntityNotParsableException;
@@ -179,6 +181,10 @@ class SyncPerformer {
         } catch (final UnexpectedResponseCode e) {
             syncResult.stats.numParseExceptions++; // hard error
             sendErrorIntent(context, UNEXPECTED_RESPONSE_CODE.getCode(), e.getMessage());
+            return HttpConnection.Result.UPLOAD_FAILED;
+        } catch (final AccountNotActivated e) {
+            syncResult.stats.numAuthExceptions++; // hard error
+            sendErrorIntent(context, ACCOUNT_NOT_ACTIVATED.getCode(), e.getMessage());
             return HttpConnection.Result.UPLOAD_FAILED;
         } catch (final MeasurementTooLarge e) {
             syncResult.stats.numSkippedEntries++;

--- a/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/SyncPerformer.java
@@ -19,6 +19,7 @@
 package de.cyface.synchronization;
 
 import static de.cyface.serializer.DataSerializable.humanReadableSize;
+import static de.cyface.synchronization.ErrorHandler.ErrorCode.UNEXPECTED_RESPONSE_CODE;
 import static de.cyface.synchronization.ErrorHandler.sendErrorIntent;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.BAD_REQUEST;
 import static de.cyface.synchronization.ErrorHandler.ErrorCode.ENTITY_NOT_PARSABLE;
@@ -60,6 +61,7 @@ import de.cyface.synchronization.exception.SynchronisationException;
 import de.cyface.synchronization.exception.SynchronizationInterruptedException;
 import de.cyface.synchronization.exception.TooManyRequestsException;
 import de.cyface.synchronization.exception.UnauthorizedException;
+import de.cyface.synchronization.exception.UnexpectedResponseCode;
 import de.cyface.synchronization.exception.UploadSessionExpired;
 
 /**
@@ -68,7 +70,7 @@ import de.cyface.synchronization.exception.UploadSessionExpired;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 6.0.0
+ * @version 6.1.0
  * @since 2.0.0
  */
 class SyncPerformer {
@@ -173,6 +175,10 @@ class SyncPerformer {
         } catch (final UploadSessionExpired e) {
             syncResult.stats.numIoExceptions++; // Try again
             sendErrorIntent(context, UPLOAD_SESSION_EXPIRED.getCode(), e.getMessage());
+            return HttpConnection.Result.UPLOAD_FAILED;
+        } catch (final UnexpectedResponseCode e) {
+            syncResult.stats.numParseExceptions++; // hard error
+            sendErrorIntent(context, UNEXPECTED_RESPONSE_CODE.getCode(), e.getMessage());
             return HttpConnection.Result.UPLOAD_FAILED;
         } catch (final MeasurementTooLarge e) {
             syncResult.stats.numSkippedEntries++;

--- a/synchronization/src/main/java/de/cyface/synchronization/exception/AccountNotActivated.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/exception/AccountNotActivated.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface SDK for Android.
+ *
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.synchronization.exception;
+
+/**
+ * An {@code Exception} thrown when the server responded that the user account is not activated.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 7.1.0
+ */
+public class AccountNotActivated extends Exception {
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
+     */
+    public AccountNotActivated(final String detailedMessage) {
+        super(detailedMessage);
+    }
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public AccountNotActivated(final String detailedMessage, final Exception cause) {
+        super(detailedMessage, cause);
+    }
+
+    /**
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public AccountNotActivated(final Exception cause) {
+        super(cause);
+    }
+}

--- a/synchronization/src/main/java/de/cyface/synchronization/exception/UnexpectedResponseCode.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/exception/UnexpectedResponseCode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface SDK for Android.
+ *
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.synchronization.exception;
+
+/**
+ * An {@code Exception} thrown when the server responded with an unexpected status code.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 7.1.0
+ */
+public class UnexpectedResponseCode extends Exception {
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
+     */
+    public UnexpectedResponseCode(final String detailedMessage) {
+        super(detailedMessage);
+    }
+
+    /**
+     * @param detailedMessage A more detailed message explaining the context for this <code>Exception</code>.
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public UnexpectedResponseCode(final String detailedMessage, final Exception cause) {
+        super(detailedMessage, cause);
+    }
+
+    /**
+     * @param cause The <code>Exception</code> that caused this one.
+     */
+    public UnexpectedResponseCode(final Exception cause) {
+        super(cause);
+    }
+}

--- a/synchronization/src/main/res/values-de/strings.xml
+++ b/synchronization/src/main/res/values-de/strings.xml
@@ -28,6 +28,7 @@
     <string name="error_message_host_unresolvable">Server unauffindbar. Bitte Internet-Verbindung prüfen.</string>
     <string name="error_message_upload_session_expired">Upload Sitzung abgelaufen.</string>
     <string name="error_message_unexpected_response_code">Server Antworttyp unerwartet</string>
+    <string name="error_message_account_not_activated">Nutzerkonto noch nicht aktiviert. Bitte prüfen Sie Ihre E-Mails.</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unerwarteter Fehler</string>

--- a/synchronization/src/main/res/values-de/strings.xml
+++ b/synchronization/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
 
     <!-- Login errors -->
     <string name="error_message_unknown_authentication_error">Login fehlgeschlagen</string>
-    <string name="error_message_credentials_incorrect">Zugangsdaten inkorrekt</string>
+    <string name="error_message_credentials_incorrect">Zugangsdaten inkorrekt. Bitte loggen Sie sich mit anderen Zugangsdaten ein.</string>
     <string name="error_message_authentication_canceled">Login abgebrochen</string>
 
     <!-- Synchronization errors -->

--- a/synchronization/src/main/res/values-de/strings.xml
+++ b/synchronization/src/main/res/values-de/strings.xml
@@ -27,6 +27,7 @@
     <string name="error_message_too_many_requests">Zu viele Anfragen</string>
     <string name="error_message_host_unresolvable">Server unauffindbar. Bitte Internet-Verbindung prüfen.</string>
     <string name="error_message_upload_session_expired">Upload Sitzung abgelaufen.</string>
+    <string name="error_message_unexpected_response_code">Server Antworttyp unerwartet</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unerwarteter Fehler</string>

--- a/synchronization/src/main/res/values-it/strings.xml
+++ b/synchronization/src/main/res/values-it/strings.xml
@@ -3,7 +3,7 @@
 
     <!-- Login errors -->
     <string name="error_message_unknown_authentication_error">Login fallito</string>
-    <string name="error_message_credentials_incorrect">Credenziali di accesso errate</string>
+    <string name="error_message_credentials_incorrect">Credenziali di accesso errate. Si prega di effettuare il login con credenziali diverse.</string>
     <string name="error_message_authentication_canceled">Login annullato</string>
 
     <!-- Synchronization errors -->

--- a/synchronization/src/main/res/values-it/strings.xml
+++ b/synchronization/src/main/res/values-it/strings.xml
@@ -28,6 +28,7 @@
     <string name="error_message_host_unresolvable">Impossibile trovare il server. Si prega di controllare la connessione internet.</string>
     <string name="error_message_upload_session_expired">Sessione di caricamento scaduta.</string>
     <string name="error_message_unexpected_response_code">Codice di risposta inatteso</string>
+    <string name="error_message_account_not_activated">Account non attivato. Per favore controlla le tue email.</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Errore imprevisto</string>

--- a/synchronization/src/main/res/values-it/strings.xml
+++ b/synchronization/src/main/res/values-it/strings.xml
@@ -27,6 +27,7 @@
     <string name="error_message_too_many_requests">Troppe richieste</string>
     <string name="error_message_host_unresolvable">Impossibile trovare il server. Si prega di controllare la connessione internet.</string>
     <string name="error_message_upload_session_expired">Sessione di caricamento scaduta.</string>
+    <string name="error_message_unexpected_response_code">Codice di risposta inatteso</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Errore imprevisto</string>

--- a/synchronization/src/main/res/values/strings.xml
+++ b/synchronization/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <!-- Login errors -->
     <string name="error_message_unknown_authentication_error">Login failed</string>
-    <string name="error_message_credentials_incorrect">Credentials incorrect</string>
+    <string name="error_message_credentials_incorrect">Credentials incorrect. Please login with different credentials.</string>
     <string name="error_message_authentication_canceled">Login canceled</string>
 
     <!-- Synchronization errors -->

--- a/synchronization/src/main/res/values/strings.xml
+++ b/synchronization/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="error_message_too_many_requests">Too many requests</string>
     <string name="error_message_host_unresolvable">Cannot find server. Please check your internet connection.</string>
     <string name="error_message_upload_session_expired">Upload session expired.</string>
+    <string name="error_message_unexpected_response_code">Unexpected response code</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unexpected error</string>

--- a/synchronization/src/main/res/values/strings.xml
+++ b/synchronization/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="error_message_host_unresolvable">Cannot find server. Please check your internet connection.</string>
     <string name="error_message_upload_session_expired">Upload session expired.</string>
     <string name="error_message_unexpected_response_code">Unexpected response code</string>
+    <string name="error_message_account_not_activated">Account not activated. Please check your emails.</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unexpected error</string>


### PR DESCRIPTION
Adds the support for:
- 428: Account not activated response from the Auth server
- unexpected error codes (before, the processed crashed, e.g. before the 428 handling was added)