### PR TITLE
Task/stad 333 return mid when stopping paused measurement update version 7

### DIFF
--- a/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
+++ b/datacapturing/src/androidTestCyface/java/de/cyface/datacapturing/DataCapturingServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Cyface GmbH
+ * Copyright 2017-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -94,7 +94,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.7.3
+ * @version 5.7.4
  * @since 2.0.0
  */
 @RunWith(AndroidJUnit4.class)
@@ -737,7 +737,7 @@ public class DataCapturingServiceTest {
 
         final long measurementIdentifier = startAndCheckThatLaunched();
         pauseAndCheckThatStopped(measurementIdentifier);
-        stopAndCheckThatStopped(-1); // -1 because it's already stopped
+        stopAndCheckThatStopped(measurementIdentifier); // stop paused returns mid, too [STAD-333]
     }
 
     /**
@@ -760,7 +760,7 @@ public class DataCapturingServiceTest {
 
             final long measurementIdentifier = startAndCheckThatLaunched();
             pauseAndCheckThatStopped(measurementIdentifier);
-            stopAndCheckThatStopped(-1); // -1 because it's already stopped
+            stopAndCheckThatStopped(measurementIdentifier); // stop paused returns mid, too [STAD-333]
         }
     }
 
@@ -1013,7 +1013,7 @@ public class DataCapturingServiceTest {
         final long measurementIdentifier = startAndCheckThatLaunched();
         pauseAndCheckThatStopped(measurementIdentifier);
         oocut.changeModalityType(CAR);
-        stopAndCheckThatStopped(-1L); // -1 because it's already stopped
+        stopAndCheckThatStopped(measurementIdentifier); // stop paused returns mid, too [STAD-333]
         final List<Event> modalityTypeChanges = oocut.persistenceLayer.loadEvents(measurementIdentifier,
                 Event.EventType.MODALITY_TYPE_CHANGE);
         assertThat(modalityTypeChanges.size(), is(equalTo(2)));

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Cyface GmbH
+ * Copyright 2017-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -106,7 +106,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 18.0.4
+ * @version 18.0.5
  * @since 1.0.0
  */
 public abstract class DataCapturingService {
@@ -817,16 +817,15 @@ public abstract class DataCapturingService {
      * command was executed.
      *
      * @param context The {@link Context} used to send the broadcast from
-     * @param measurementIdentifier The id of the stopped measurement if {@code #stoppedSuccessfully}
+     * @param measurementIdentifier The id of the stopped measurement
      * @param stoppedSuccessfully True if the background service was still alive before stopped
      */
     private void sendServiceStoppedBroadcast(final Context context, final long measurementIdentifier,
             final boolean stoppedSuccessfully) {
         final Intent stoppedBroadcastIntent = new Intent(MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED);
-        if (stoppedSuccessfully) {
-            Validate.isTrue(measurementIdentifier > 0L);
-            stoppedBroadcastIntent.putExtra(MEASUREMENT_ID, measurementIdentifier);
-        }
+        // The measurement id should always be set, also if `stoppedSuccessfully=false` [STAD-333]
+        Validate.isTrue(measurementIdentifier > 0L);
+        stoppedBroadcastIntent.putExtra(MEASUREMENT_ID, measurementIdentifier);
         stoppedBroadcastIntent.putExtra(STOPPED_SUCCESSFULLY, stoppedSuccessfully);
         LocalBroadcastManager.getInstance(context).sendBroadcast(stoppedBroadcastIntent);
     }

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -1274,6 +1274,7 @@ public abstract class DataCapturingService {
                             "Data capturing requires permission to access geo location via satellite. Was not granted or revoked!"));
                     break;
                 case MessageCodes.SERVICE_STOPPED:
+                case MessageCodes.SERVICE_STOPPED_ITSELF:
                     listener.onCapturingStopped();
                     break;
                 default:


### PR DESCRIPTION
This fix solves the bug STAD-333, i.e. I [released](https://github.com/cyface-de/android-backend/pull/241) it as Hot-Fix Version `6.2.1`.

This PR ports the fix to the current `main` (i.e. I'll release it as `7.2.1`).

---
You can ignore, that the CI shows "Aborted", I triggered the CI manually again, the steps where successful for **this branch**.