### PR TITLE
Upgrade transfer file and persistence file version to 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 
     // Cyface dependencies
     cyfaceUtilsVersion = "3.2.2"
-    cyfaceSerializationVersion = "2.0.0-beta1"
+    cyfaceSerializationVersion = "2.0.0"
 
     // Android SDK versions
     minSdkVersion = 21

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.8.2
+ * @version 2.8.3
  * @since 1.0.0
  */
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 
     // Cyface dependencies
     cyfaceUtilsVersion = "3.2.2"
-    cyfaceSerializationVersion = "1.0.2"
+    cyfaceSerializationVersion = "2.0.0-beta1"
 
     // Android SDK versions
     minSdkVersion = 21

--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Cyface GmbH
+ * Copyright 2017-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -69,7 +69,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 18.0.0
+ * @version 18.0.1
  * @since 2.0.0
  */
 public class PersistenceLayer<B extends PersistenceBehaviour> {
@@ -79,7 +79,7 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
      * It's stored in each {@link Measurement}'s {@link MeasurementTable} entry and allows to have stored and process
      * measurements and files with different {@code #PERSISTENCE_FILE_FORMAT_VERSION} at the same time.
      */
-    public final static short PERSISTENCE_FILE_FORMAT_VERSION = 2;
+    public final static short PERSISTENCE_FILE_FORMAT_VERSION = 3;
     /**
      * The {@link Context} required to locate the app's internal storage directory.
      */

--- a/persistence/src/main/java/de/cyface/persistence/serialization/MeasurementSerializer.java
+++ b/persistence/src/main/java/de/cyface/persistence/serialization/MeasurementSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Cyface GmbH
+ * Copyright 2018-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -53,7 +53,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 8.0.0
+ * @version 8.0.1
  * @since 2.0.0
  */
 public final class MeasurementSerializer {
@@ -62,7 +62,7 @@ public final class MeasurementSerializer {
      * The current version of the transferred file. This is always specified by the first two bytes of the file
      * transferred and helps compatible APIs to process data from different client versions.
      */
-    public final static short TRANSFER_FILE_FORMAT_VERSION = 2;
+    public final static short TRANSFER_FILE_FORMAT_VERSION = 3;
     /**
      * Since our current API Level does not support {@code Short.Bytes}.
      */

--- a/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
+++ b/synchronization/src/androidTestMovebis/java/de/cyface/synchronization/SyncPerformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Cyface GmbH
+ * Copyright 2018-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -91,7 +91,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.1.0
+ * @version 2.1.1
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  * @since 2.0.0
  */
@@ -180,7 +180,7 @@ public class SyncPerformerTest {
             final var metaData = new RequestMetaData(deviceId, String.valueOf(measurementIdentifier),
                     "testOsVersion", "testDeviceType", "testAppVersion",
                     measurement.getDistance(), locationCount, startRecord, endRecord,
-                    Modality.BICYCLE.getDatabaseIdentifier(), 2);
+                    Modality.BICYCLE.getDatabaseIdentifier(), 3);
 
             // Mock the actual post request
             doThrow(new ConflictException("Test ConflictException"))
@@ -314,7 +314,7 @@ public class SyncPerformerTest {
         return new RequestMetaData(deviceId, String.valueOf(id.getMeasurementIdentifier()),
                 "testOsVersion", "testDeviceType", "testAppVersion",
                 measurement.getDistance(), locationCount, startRecord, endRecord,
-                Modality.BICYCLE.getDatabaseIdentifier(), 2);
+                Modality.BICYCLE.getDatabaseIdentifier(), 3);
     }
 
     private File loadSerializedCompressed(ContentProviderClient client, long measurementIdentifier)

--- a/synchronization/src/test/java/de/cyface/synchronization/HttpConnectionTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/HttpConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Cyface GmbH
+ * Copyright 2018-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -36,7 +36,7 @@ import de.cyface.persistence.model.Modality;
  * Tests whether our default implementation of the {@link Http} protocol works as expected.
  *
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 2.0.1
  * @since 4.0.0
  */
 public class HttpConnectionTest {
@@ -53,7 +53,7 @@ public class HttpConnectionTest {
         final var endLocation = generateRequestMetaDataGeoLocation(10);
         final var metaData = new RequestMetaData(id.getDeviceIdentifier(),
                 String.valueOf(id.getMeasurementIdentifier()), "test_osVersion", "test_deviceType", "test_appVersion",
-                10.0, 5, startLocation, endLocation, Modality.BICYCLE.getDatabaseIdentifier(), 2);
+                10.0, 5, startLocation, endLocation, Modality.BICYCLE.getDatabaseIdentifier(), 3);
 
         // Act
         final Map<String, String> result = HttpConnection.preRequestBody(metaData);
@@ -74,7 +74,7 @@ public class HttpConnectionTest {
         expected.put("length", "10.0");
         expected.put("locationCount", "5");
         expected.put("modality", "BICYCLE");
-        expected.put("formatVersion", "2");
+        expected.put("formatVersion", "3");
         assertThat(result, is(equalTo(expected)));
     }
 }

--- a/synchronization/src/test/java/de/cyface/synchronization/MeasurementSerializerTest.java
+++ b/synchronization/src/test/java/de/cyface/synchronization/MeasurementSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Cyface GmbH
+ * Copyright 2018-2022 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -94,7 +94,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 3.0.0
+ * @version 3.0.1
  * @since 2.0.0
  */
 @RunWith(RobolectricTestRunner.class)
@@ -282,7 +282,7 @@ public class MeasurementSerializerTest {
     public void testSerializeCompressedMeasurement() throws CursorIsNullException {
 
         // If you need to change the sample point counts (and this) make sure the test work with the previous counts
-        final long SERIALIZED_COMPRESSED_SIZE = 95L; // When compression Deflater(level 9, true)
+        final long SERIALIZED_COMPRESSED_SIZE = 97L; // When compression Deflater(level 9, true)
         final File compressedTransferBytes = oocut.writeSerializedCompressed(loader, SAMPLE_MEASUREMENT_ID,
                 persistence);
         assertThat(compressedTransferBytes.length(), is(equalTo(SERIALIZED_COMPRESSED_SIZE)));
@@ -397,13 +397,13 @@ public class MeasurementSerializerTest {
     private Measurement deserializeTransferFile(byte[] bytes) throws InvalidProtocolBufferException {
         final ByteBuffer buffer = ByteBuffer.wrap(bytes);
         final short formatVersion = buffer.order(ByteOrder.BIG_ENDIAN).getShort(0);
-        assertThat(formatVersion, is(equalTo((short)2)));
+        assertThat(formatVersion, is(equalTo((short)3)));
 
         // slice from index 5 to index 9
         final byte[] protoBytes = Arrays.copyOfRange(bytes, BYTES_IN_HEADER, bytes.length);
 
         final Measurement deserialized = parseFrom(protoBytes);
-        assertThat(deserialized.getFormatVersion(), is(equalTo(2)));
+        assertThat(deserialized.getFormatVersion(), is(equalTo(3)));
         assertThat(deserialized.getLocationRecords().getTimestampCount(), is(equalTo(SAMPLE_GEO_LOCATIONS)));
         assertThat(deserialized.getAccelerationsBinary().getAccelerations(0).getTimestampCount(), is(equalTo(SAMPLE_ACCELERATION_POINTS)));
         assertThat(deserialized.getRotationsBinary().getRotations(0).getTimestampCount(), is(equalTo(SAMPLE_ROTATION_POINTS)));


### PR DESCRIPTION
Makes the SDK use the new `serializer` 2.0.0 with binary format 3