### PR TITLE
[RFR-246] Add workaround for rebinding bug to Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -552,10 +552,59 @@ public class DataCapturingButton implements DataCapturingListener {
         dataCapturingService.stop(new ShutDownFinishedHandler(MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED) {
             @Override
             public void shutDownFinished(final long measurementIdentifier) {
-                // Your logic, e.g.:
-                setButtonStatus(button, FINISHED);
+                // Disabled on Android 13+ for workaround, see `timeoutHandler` below [RFR-246]
+                if (Build.VERSION.SDK_INT < 33) {
+                    // Your logic, e.g.:
+                    setButtonStatus(button, FINISHED);
+                    setButtonEnabled(true);
+                }
             }
         });
+
+        // Workaround for flaky `rebind` on Android 13+ [RFR-246]
+        // - Don't wait for `shutDownFinished` to be called (flaky due to the bug).
+        // - Use a static 500ms delay to give the measurement some time to stop.
+        if (Build.VERSION.SDK_INT >= 33) {
+            final var timeoutHandler = new Handler(context.getMainLooper());
+            timeoutHandler.postAtTime(() -> {
+                // Attention: The measurementId is not available in this workaround!
+
+                // Your logic, e.g.:
+                setButtonStatus(button, FINISHED);
+                setButtonEnabled(true);
+            }, SystemClock.uptimeMillis() + 500L);
+        }
+    }
+
+    private void pauseCapturing() {
+        dataCapturingService.pause(new ShutDownFinishedHandler(MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED) {
+            @Override
+            public void shutDownFinished(final long measurementIdentifier) {
+                // Disabled on Android 13+ for workaround, see `timeoutHandler` below [RFR-246]
+                if (Build.VERSION.SDK_INT < 33) {
+                    // Your logic, e.g.:
+                    setButtonStatus(button, FINISHED);
+                    setButtonEnabled(true);
+                }
+            }
+        });
+
+        // Workaround for flaky `rebind` on Android 13+ [RFR-246]
+        // - Don't wait for `shutDownFinished` to be called (flaky due to the bug).
+        // - Use a static 500ms delay to give the measurement some time to stop.
+        if (Build.VERSION.SDK_INT >= 33) {
+            // Your logic, e.g.
+            setButtonStatus(button, PAUSED); // avoids button to flip to "stopped" before "paused"
+
+            final var timeoutHandler = new Handler(context.getMainLooper());
+            timeoutHandler.postAtTime(() -> {
+                // Attention: The measurementId is not available in this workaround!
+
+                // Your logic, e.g.:
+                // setButtonStatus(button, PAUSED); // Don't do this here but before the timeout
+                setButtonEnabled(true);
+            }, SystemClock.uptimeMillis() + 500L);
+        }
     }
 
     private void resumeCapturing() {

--- a/README.adoc
+++ b/README.adoc
@@ -576,44 +576,12 @@ public class DataCapturingButton implements DataCapturingListener {
         }
     }
 
-    private void pauseCapturing() {
-        dataCapturingService.pause(new ShutDownFinishedHandler(MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED) {
-            @Override
-            public void shutDownFinished(final long measurementIdentifier) {
-                // Disabled on Android 13+ for workaround, see `timeoutHandler` below [RFR-246]
-                if (Build.VERSION.SDK_INT < 33) {
-                    // Your logic, e.g.:
-                    setButtonStatus(button, FINISHED);
-                    setButtonEnabled(true);
-                }
-            }
-        });
-
-        // Workaround for flaky `rebind` on Android 13+ [RFR-246]
-        // - Don't wait for `shutDownFinished` to be called (flaky due to the bug).
-        // - Use a static 500ms delay to give the measurement some time to stop.
-        if (Build.VERSION.SDK_INT >= 33) {
-            // Your logic, e.g.
-            setButtonStatus(button, PAUSED); // avoids button to flip to "stopped" before "paused"
-
-            final var timeoutHandler = new Handler(context.getMainLooper());
-            timeoutHandler.postAtTime(() -> {
-                // Attention: The measurementId is not available in this workaround!
-
-                // Your logic, e.g.:
-                // setButtonStatus(button, PAUSED); // Don't do this here but before the timeout
-                setButtonEnabled(true);
-            }, SystemClock.uptimeMillis() + 500L);
+    @Overwrite
+    public void onCapturingStopped() {
+        // Disabled on Android 13+ for workaround, see `stop/pauseCapturing()` [RFR-246]
+        if (Build.VERSION.SDK_INT < 33) {
+            setButtonStatus(button, FINISHED);
         }
-    }
-
-    private void resumeCapturing() {
-        dataCapturingService.resume(new StartUpFinishedHandler(MessageCodes.getServiceStartedActionId(context.getPackageName())) {
-             @Override
-             public void startUpFinished(final long measurementIdentifier) {
-                 setButtonStatus(button, OPEN);
-             }
-         });
     }
 }
 ----
@@ -651,6 +619,43 @@ public class DataCapturingButton implements DataCapturingListener {
             }
         });
         return true;
+    }
+
+    private void pauseCapturing() {
+        dataCapturingService.pause(new ShutDownFinishedHandler(MessageCodes.LOCAL_BROADCAST_SERVICE_STOPPED) {
+            @Override
+            public void shutDownFinished(final long measurementIdentifier) {
+                // Disabled on Android 13+ for workaround, see `timeoutHandler` below [RFR-246]
+                if (Build.VERSION.SDK_INT < 33) {
+                    // Your logic, e.g.:
+                    setButtonStatus(button, PAUSED);
+                    setButtonEnabled(true);
+                }
+            }
+        });
+
+        // Workaround for flaky `rebind` on Android 13+ [RFR-246]
+        // - Don't wait for `shutDownFinished` to be called (flaky due to the bug).
+        // - Use a static 500ms delay to give the measurement some time to stop.
+        if (Build.VERSION.SDK_INT >= 33) {
+            final var timeoutHandler = new Handler(context.getMainLooper());
+            timeoutHandler.postAtTime(() -> {
+                // Attention: The measurementId is not available in this workaround!
+
+                // Your logic, e.g.:
+                setButtonStatus(button, PAUSED);
+                setButtonEnabled(true);
+            }, SystemClock.uptimeMillis() + 500L);
+        }
+    }
+
+    private void resumeCapturing() {
+        dataCapturingService.resume(new StartUpFinishedHandler(MessageCodes.getServiceStartedActionId(context.getPackageName())) {
+             @Override
+             public void startUpFinished(final long measurementIdentifier) {
+                 setButtonStatus(button, OPEN);
+             }
+         });
     }
 }
 ----


### PR DESCRIPTION
This PR adds the workaround required to avoid the flaky `rebind` bug on Android 13 to the Readme.

See https://github.com/cyface-de/android-app/pull/32