### PR TITLE
Task/rfr 253 replace deprecated handler constructor

### DIFF
--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -56,7 +56,6 @@ import android.net.ConnectivityManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
-import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -279,7 +278,7 @@ public abstract class DataCapturingService {
             throw new SetupException("Android connectivity manager is not available!");
         }
         surveyor = new WiFiSurveyor(context, connectivityManager, authority, accountType);
-        fromServiceMessageHandler = new FromServiceMessageHandler(context.getMainLooper(), context, this);
+        fromServiceMessageHandler = new FromServiceMessageHandler(context, this);
         // The listeners are automatically removed when the service is destroyed (e.g. app kill)
         fromServiceMessageHandler.addListener(capturingListener);
         this.fromServiceMessenger = new Messenger(fromServiceMessageHandler);
@@ -1184,7 +1183,7 @@ public abstract class DataCapturingService {
      *
      * @author Klemens Muthmann
      * @author Armin Schnabel
-     * @version 3.0.0
+     * @version 2.0.1
      * @since 2.0.0
      */
     private static class FromServiceMessageHandler extends Handler {
@@ -1205,13 +1204,11 @@ public abstract class DataCapturingService {
         /**
          * Creates a new completely initialized <code>FromServiceMessageHandler</code>.
          *
-         * @param looper The {@code Looper} to the handler should run on.
          * @param context The Android context this handler is running under.
          * @param dataCapturingService The service which calls this handler.
          */
-        public FromServiceMessageHandler(@NonNull Looper looper, final Context context,
-                final DataCapturingService dataCapturingService) {
-            super(looper);
+        public FromServiceMessageHandler(final Context context, final DataCapturingService dataCapturingService) {
+            super(context.getMainLooper());
             this.context = context;
             this.listener = new HashSet<>();
             this.dataCapturingService = dataCapturingService;

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -56,6 +56,7 @@ import android.net.ConnectivityManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -278,7 +279,7 @@ public abstract class DataCapturingService {
             throw new SetupException("Android connectivity manager is not available!");
         }
         surveyor = new WiFiSurveyor(context, connectivityManager, authority, accountType);
-        fromServiceMessageHandler = new FromServiceMessageHandler(context, this);
+        fromServiceMessageHandler = new FromServiceMessageHandler(context.getMainLooper(), context, this);
         // The listeners are automatically removed when the service is destroyed (e.g. app kill)
         fromServiceMessageHandler.addListener(capturingListener);
         this.fromServiceMessenger = new Messenger(fromServiceMessageHandler);
@@ -1203,9 +1204,14 @@ public abstract class DataCapturingService {
 
         /**
          * Creates a new completely initialized <code>FromServiceMessageHandler</code>.
+         *
+         * @param looper The {@code Looper} to the handler should run on.
+         * @param context The Android context this handler is running under.
+         * @param dataCapturingService The service which calls this handler.
          */
-        FromServiceMessageHandler(@NonNull final Context context,
-                @NonNull final DataCapturingService dataCapturingService) {
+        public FromServiceMessageHandler(@NonNull Looper looper, final Context context,
+                final DataCapturingService dataCapturingService) {
+            super(looper);
             this.context = context;
             this.listener = new HashSet<>();
             this.dataCapturingService = dataCapturingService;

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Cyface GmbH
+ * Copyright 2017-2023 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -109,7 +109,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 18.0.6
+ * @version 18.0.7
  * @since 1.0.0
  */
 public abstract class DataCapturingService {
@@ -1184,7 +1184,7 @@ public abstract class DataCapturingService {
      *
      * @author Klemens Muthmann
      * @author Armin Schnabel
-     * @version 2.0.0
+     * @version 3.0.0
      * @since 2.0.0
      */
     private static class FromServiceMessageHandler extends Handler {

--- a/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/DataCapturingService.java
@@ -1207,7 +1207,7 @@ public abstract class DataCapturingService {
          * @param context The Android context this handler is running under.
          * @param dataCapturingService The service which calls this handler.
          */
-        public FromServiceMessageHandler(final Context context, final DataCapturingService dataCapturingService) {
+        FromServiceMessageHandler(@NonNull final Context context, @NonNull final DataCapturingService dataCapturingService) {
             super(context.getMainLooper());
             this.context = context;
             this.listener = new HashSet<>();

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -221,8 +221,6 @@ public class DataCapturingBackgroundService extends Service implements Capturing
         }
 
         // Allows other parties to ping this service to see if it is running
-        // We cannot use the deviceId as device-unique app identifier as we need the authority (persistence) for this
-        // which we cannot pass via bind() as documented by the {@link #onBind()} method.
         pingReceiver = new PingReceiver(GLOBAL_BROADCAST_PING, GLOBAL_BROADCAST_PONG);
         registerReceiver(pingReceiver, new IntentFilter(GLOBAL_BROADCAST_PING));
         Log.d(TAG, "onCreate: Ping Receiver registered");

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -51,6 +51,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.Parcelable;
@@ -113,7 +114,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
      * The Android <code>Messenger</code> used to send IPC messages, informing the caller about the current status of
      * data capturing.
      */
-    private final Messenger callerMessenger = new Messenger(new MessageHandler(this));
+    private final Messenger callerMessenger = new Messenger(new MessageHandler(getMainLooper(), this));
     /**
      * The list of clients receiving messages from this service as well as sending control messages.
      */
@@ -539,9 +540,11 @@ public class DataCapturingBackgroundService extends Service implements Capturing
          * Creates a new completely initialized {@link MessageHandler} for messages to this
          * service.
          *
+         * @param looper The {@code Looper} to the handler should run on.
          * @param context The {@link DataCapturingBackgroundService} receiving messages via this handler.
          */
-        MessageHandler(final @NonNull DataCapturingBackgroundService context) {
+        MessageHandler(@NonNull Looper looper, final @NonNull DataCapturingBackgroundService context) {
+            super(looper);
             this.context = new WeakReference<>(context);
         }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -51,7 +51,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
-import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.Parcelable;
@@ -220,7 +219,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
             return;
         }
 
-        callerMessenger = new Messenger(new MessageHandler(getMainLooper(), this));
+        callerMessenger = new Messenger(new MessageHandler(this));
 
         // Allows other parties to ping this service to see if it is running
         pingReceiver = new PingReceiver(GLOBAL_BROADCAST_PING, GLOBAL_BROADCAST_PONG);
@@ -541,11 +540,10 @@ public class DataCapturingBackgroundService extends Service implements Capturing
          * Creates a new completely initialized {@link MessageHandler} for messages to this
          * service.
          *
-         * @param looper The {@code Looper} to the handler should run on.
          * @param context The {@link DataCapturingBackgroundService} receiving messages via this handler.
          */
-        MessageHandler(@NonNull Looper looper, final @NonNull DataCapturingBackgroundService context) {
-            super(looper);
+        MessageHandler(final @NonNull DataCapturingBackgroundService context) {
+            super(context.getMainLooper());
             this.context = new WeakReference<>(context);
         }
 

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -114,7 +114,7 @@ public class DataCapturingBackgroundService extends Service implements Capturing
      * The Android <code>Messenger</code> used to send IPC messages, informing the caller about the current status of
      * data capturing.
      */
-    private final Messenger callerMessenger = new Messenger(new MessageHandler(getMainLooper(), this));
+    private Messenger callerMessenger;
     /**
      * The list of clients receiving messages from this service as well as sending control messages.
      */
@@ -219,6 +219,8 @@ public class DataCapturingBackgroundService extends Service implements Capturing
             Log.v(TAG, "onBind: Ping Receiver was already registered");
             return;
         }
+
+        callerMessenger = new Messenger(new MessageHandler(getMainLooper(), this));
 
         // Allows other parties to ping this service to see if it is running
         pingReceiver = new PingReceiver(GLOBAL_BROADCAST_PING, GLOBAL_BROADCAST_PONG);

--- a/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
+++ b/datacapturing/src/main/java/de/cyface/datacapturing/backend/DataCapturingBackgroundService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Cyface GmbH
+ * Copyright 2017-2023 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -89,7 +89,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.1.5
+ * @version 7.1.6
  * @since 2.0.0
  */
 public class DataCapturingBackgroundService extends Service implements CapturingProcessListener {
@@ -522,7 +522,8 @@ public class DataCapturingBackgroundService extends Service implements Capturing
      * - We don't use Broadcasts here to reduce the amount of broadcasts.
      *
      * @author Klemens Muthmann
-     * @version 1.0.1
+     * @author Armin Schnabel
+     * @version 2.0.0
      * @since 1.0.0
      */
     private final static class MessageHandler extends Handler {


### PR DESCRIPTION
This PR replaces the deprecated `Handler()` constructor with the constructor which injects an explicit Looper.

Unfortunately, this does not fix the `rebind()` bug, but I might be able to trace down the cause of the `rebind` bug with the reproducer app, but that's another story.