### PR TITLE
[STAD-434] Move CI to Github Actions

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -1,7 +1,7 @@
 # This workflow ensures the building step works
 #
 # @author Armin Schnabel
-# @version 1.0.2
+# @version 1.0.3
 # @since 5.0.0
 name: Gradle Build
 
@@ -9,20 +9,18 @@ on:
   push:
     branches:
       - main
-      - release
   pull_request:
     branches:
       - main
-      - release
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -34,5 +32,6 @@ jobs:
           echo "githubUser=${{ secrets.GH_READ_ACCOUNT }}" >> gradle.properties
           echo "githubToken=${{ secrets.GH_READ_TOKEN }}" >> gradle.properties
 
+      # Executing build here on Ubuntu stack (1/10th costs of MacOS stack)
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -1,0 +1,76 @@
+# This workflow ensures the connected tests keep working
+#
+# @author Armin Schnabel
+# @version 1.0.0
+# @since 7.4.0
+name: Gradle Connected Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    # Faster, but MacOS costs 8 ct/min instead of 0.8 ct/min of on Linux.
+    # Unfortunately, `DataCapturingServiceTest.testDisconnectReconnect` fails on linux stack.
+    # But as this is a public repository, Github Actions are currently free of charge.
+    runs-on: macos-latest # as recommended in `actions/android-emulator-runner`
+
+    # To test against multiple APIs
+    strategy:
+      matrix:
+        api-level: [ 28 ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Add gradle.properties
+        run: |
+          # Use a personal read token to install the Cyface Utils package
+          cp gradle.properties.template gradle.properties
+          echo "githubUser=${{ secrets.GH_READ_ACCOUNT }}" >> gradle.properties
+          echo "githubToken=${{ secrets.GH_READ_TOKEN }}" >> gradle.properties
+
+      # Not executing build here on MacOS stack (10x costs, if private repository)
+      #- name: Build with Gradle
+      #  run: ./gradlew build
+
+      # Add caching to speed up connected tests below (see `actions/android-emulator-runner`)
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          disable-animations: true
+          script: echo "Generated AVD snapshot for caching."
+
+      # Only execute mock tests to exclude `@FlakyTest`s (instead of running `connectedCheck`)
+      - name: Connected tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save
+          disable-animations: true
+          script: ./gradlew :persistence:connectedDebugAndroidTest :datacapturing:connectedCyfaceMockDebugAndroidTest :synchronization:connectedCyfaceMockDebugAndroidTest :datacapturing:connectedMovebisMockDebugAndroidTest :synchronization:connectedMovebisMockDebugAndroidTest
+          # To execute a single test class
+          #script: ./gradlew :datacapturing:connectedCyfaceMockDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=de.cyface.datacapturing.DataCapturingServiceTest

--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -1,7 +1,7 @@
 # This workflow publishes a new version to the Github Registry.
 #
 # @author Armin Schnabel
-# @version 1.0.1
+# @version 1.0.2
 # @since 5.0.0
 name: Gradle Publish
 
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'


### PR DESCRIPTION
As the connected tests on Bitrise are pretty [unstable](https://addons-testing.bitrise.io/builds/ccdc65e8-c511-4aaf-abfc-572a7672a45e/testreport/ftl/testsuite/0/testcases?status=failed) for [some time](https://app.bitrise.io/app/3f7da1f067e2d183) already, we finally move the connected tests to Github Actions. The unit tests and the artifact publish workflows are already on Github Actions.

This PR ports the changes from [this SDK 6 PR](https://github.com/cyface-de/android-backend/pull/260) to the SDK 7 branch.