### PR TITLE
[STAD-455] Use Singleton to create DatabaseV6

### DIFF
--- a/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
+++ b/persistence/src/main/java/de/cyface/persistence/PersistenceLayer.java
@@ -51,7 +51,6 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.room.Room;
 
 import de.cyface.persistence.model.DataPointV6;
 import de.cyface.persistence.model.Event;
@@ -78,7 +77,7 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 17.1.0
+ * @version 17.1.1
  * @since 2.0.0
  */
 public class PersistenceLayer<B extends PersistenceBehaviour> {
@@ -149,21 +148,7 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
         this.context = context;
         this.resolver = resolver;
         this.authority = authority;
-        // From Room guide: https://developer.android.com/training/data-storage/room
-        // If the app runs in multiple processes, include enableMultiInstanceInvalidation() in the builder.
-        // That way, when when you have an instance of AppDatabase in each process, you can invalidate the shared
-        // database file in one process, and this invalidation automatically propagates to the instances of AppDatabase
-        // within other processes.
-        // Additional notes: Room itself (like SQLite, Room is thread-safe) and only uses one connection for writing.
-        // I.e. we only need to worry about deadlocks when running manual transactions (`db.beginTransaction` or
-        // `roomDb.runInTransaction`. See
-        // https://www.reddit.com/r/androiddev/comments/9s2m4x/comment/e8nklbg/?utm_source=share&utm_medium=web2x&context=3
-        // The PersistenceLayer constructor is called from main UI and non-UI threads, e.g.:
-        // - main UI thread: CyfaceDataCapturingService, DataCapturingBackgroundService/DataCapturingService,
-        // DataCapturingButton, MeasurementOverviewFragment
-        // - other threads: SyncAdapter, Event-/MeasurementDeleteController
-        this.databaseV6 = Room.databaseBuilder(context.getApplicationContext(), DatabaseV6.class, "v6")
-                .enableMultiInstanceInvalidation().build();
+        this.databaseV6 = DatabaseV6.getDatabase(context.getApplicationContext());
         this.persistenceBehaviour = persistenceBehaviour;
         this.fileAccessLayer = new DefaultFileAccess();
         final File accelerationsFolder = fileAccessLayer.getFolderPath(context, Point3dFile.ACCELERATIONS_FOLDER_NAME);
@@ -1507,7 +1492,7 @@ public class PersistenceLayer<B extends PersistenceBehaviour> {
     }
 
     /**
-     * @return
+     * @return The database for V6 specific data.
      */
     public DatabaseV6 getDatabaseV6() {
         return databaseV6;

--- a/persistence/src/main/java/de/cyface/persistence/dao/GeoLocationDao.java
+++ b/persistence/src/main/java/de/cyface/persistence/dao/GeoLocationDao.java
@@ -18,13 +18,12 @@
  */
 package de.cyface.persistence.dao;
 
-import java.util.List;
-
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Query;
 
-import de.cyface.persistence.model.GeoLocationV6;
+import java.util.List;
+
 import de.cyface.persistence.model.PersistedGeoLocation;
 
 /**
@@ -36,7 +35,6 @@ import de.cyface.persistence.model.PersistedGeoLocation;
  */
 @Dao
 public interface GeoLocationDao {
-
     @Query("SELECT * FROM location WHERE measurement_fk = :measurementId ORDER BY timestamp ASC")
     List<PersistedGeoLocation> loadAllByMeasurementId(long measurementId);
 

--- a/persistence/src/main/java/de/cyface/persistence/dao/PressureDao.java
+++ b/persistence/src/main/java/de/cyface/persistence/dao/PressureDao.java
@@ -18,14 +18,13 @@
  */
 package de.cyface.persistence.dao;
 
-import java.util.List;
-
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Query;
 
+import java.util.List;
+
 import de.cyface.persistence.model.PersistedPressure;
-import de.cyface.persistence.model.Pressure;
 
 /**
  * Data access object which provides the API to interact with the {@link PersistedPressure} database table.
@@ -36,7 +35,6 @@ import de.cyface.persistence.model.Pressure;
  */
 @Dao
 public interface PressureDao {
-
     @Query("SELECT * FROM pressure WHERE measurement_fk = :measurementId ORDER BY timestamp ASC")
     List<PersistedPressure> loadAllByMeasurementId(long measurementId);
 


### PR DESCRIPTION
This PR makes sure the `release-6` branch uses the `Room` database `v6` in a similar way we use the `Room` database on the `main` branch, so this method is tested in our test-app.