### PR TITLE
Add logout support

### DIFF
--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -374,8 +374,8 @@ public class WiFiSurveyor extends BroadcastReceiver {
      * @return The only <code>Account</code> existing
      */
     public Account getAccount() {
-        final AccountManager accountManager = AccountManager.get(context.get());
-        final Account[] cyfaceAccounts = accountManager.getAccountsByType(accountType);
+        final var accountManager = AccountManager.get(context.get());
+        final var cyfaceAccounts = accountManager.getAccountsByType(accountType);
         if (cyfaceAccounts.length == 0) {
             throw new IllegalStateException("No cyface account exists.");
         }

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Cyface GmbH
+ * Copyright 2017-2024 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -49,8 +49,6 @@ import de.cyface.utils.Validate;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 7.2.1
- * @since 2.0.0
  */
 public class WiFiSurveyor extends BroadcastReceiver {
 

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/AuthStateManager.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/AuthStateManager.kt
@@ -23,7 +23,6 @@ import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.RegistrationResponse
 import net.openid.appauth.TokenResponse
 import org.json.JSONException
-import java.io.File
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
@@ -120,38 +119,6 @@ class AuthStateManager private constructor(private val context: Context) {
                 editor.putString(KEY_STATE, state.jsonSerializeString())
             }
             check(editor.commit()) { "Failed to write state to shared prefs" }
-        } finally {
-            mPrefsLock.unlock()
-        }
-    }
-
-    /**
-     * Removes the shared preferences file, as clearing the state did not work.
-     *
-     * This was added in [LEIP-233] to fix the bug where the shared preferences were not cleared
-     * and "credentials invalid" was shown after re-login during upload.
-     */
-    /*@AnyThread
-    fun clearState() {
-        mPrefsLock.lock()
-        try {
-            val editor = mPrefs.edit()
-            editor.clear()  // Clears all data in the SharedPreferences
-            check(editor.commit()) { "Failed to clear state from shared prefs" }
-            mCurrentAuthState.set(null)  // Reset the current auth state reference
-        } finally {
-            mPrefsLock.unlock()
-        }
-    }*/
-    @AnyThread
-    fun deletePreferencesFile() {
-        mPrefsLock.lock()
-        try {
-            val file = File(context.filesDir.parentFile, "shared_prefs/$STORE_NAME.xml")
-            if (file.exists()) {
-                file.delete()
-            }
-            mCurrentAuthState.set(null)
         } finally {
             mPrefsLock.unlock()
         }

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/AuthStateManager.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/AuthStateManager.kt
@@ -23,6 +23,7 @@ import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.RegistrationResponse
 import net.openid.appauth.TokenResponse
 import org.json.JSONException
+import java.io.File
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
@@ -32,7 +33,7 @@ import java.util.concurrent.locks.ReentrantLock
  * This stores the instance in a shared preferences file, and provides thread-safe access and
  * mutation.
  */
-class AuthStateManager private constructor(context: Context) {
+class AuthStateManager private constructor(private val context: Context) {
     private val mPrefs: SharedPreferences
     private val mPrefsLock: ReentrantLock
     private val mCurrentAuthState: AtomicReference<AuthState>
@@ -125,6 +126,38 @@ class AuthStateManager private constructor(context: Context) {
                 editor.putString(KEY_STATE, state.jsonSerializeString())
             }
             check(editor.commit()) { "Failed to write state to shared prefs" }
+        } finally {
+            mPrefsLock.unlock()
+        }
+    }
+
+    /**
+     * Removes the shared preferences file, as clearing the state did not work.
+     *
+     * This was added in [LEIP-233] to fix the bug where the shared preferences were not cleared
+     * and "credentials invalid" was shown after re-login during upload.
+     */
+    /*@AnyThread
+    fun clearState() {
+        mPrefsLock.lock()
+        try {
+            val editor = mPrefs.edit()
+            editor.clear()  // Clears all data in the SharedPreferences
+            check(editor.commit()) { "Failed to clear state from shared prefs" }
+            mCurrentAuthState.set(null)  // Reset the current auth state reference
+        } finally {
+            mPrefsLock.unlock()
+        }
+    }*/
+    @AnyThread
+    fun deletePreferencesFile() {
+        mPrefsLock.lock()
+        try {
+            val file = File(context.filesDir.parentFile, "shared_prefs/$STORE_NAME.xml")
+            if (file.exists()) {
+                file.delete()
+            }
+            mCurrentAuthState.set(null)
         } finally {
             mPrefsLock.unlock()
         }

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/AuthStateManager.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/AuthStateManager.kt
@@ -34,15 +34,9 @@ import java.util.concurrent.locks.ReentrantLock
  * mutation.
  */
 class AuthStateManager private constructor(private val context: Context) {
-    private val mPrefs: SharedPreferences
-    private val mPrefsLock: ReentrantLock
-    private val mCurrentAuthState: AtomicReference<AuthState>
-
-    init {
-        mPrefs = context.getSharedPreferences(STORE_NAME, Context.MODE_PRIVATE)
-        mPrefsLock = ReentrantLock()
-        mCurrentAuthState = AtomicReference()
-    }
+    private val mPrefs: SharedPreferences = context.getSharedPreferences(STORE_NAME, Context.MODE_PRIVATE)
+    private val mPrefsLock: ReentrantLock = ReentrantLock()
+    private val mCurrentAuthState: AtomicReference<AuthState> = AtomicReference()
 
     @get:AnyThread
     val current: AuthState

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticator.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Cyface GmbH
+ * Copyright 2018-2024 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -44,8 +44,6 @@ import kotlinx.coroutines.runBlocking
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 5.1.1
- * @since 2.0.0
  */
 class CyfaceAuthenticator(private val context: Context) :
     AbstractAccountAuthenticator(context), LoginActivityProvider {

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticator.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticator.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.runBlocking
 class CyfaceAuthenticator(private val context: Context) :
     AbstractAccountAuthenticator(context), LoginActivityProvider {
 
-    private var auth: OAuth2 = OAuth2(context, settings)
+    var auth: OAuth2 = OAuth2(context, settings, "CyfaceAuthenticator")
 
     override fun editProperties(
         response: AccountAuthenticatorResponse,

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticatorService.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticatorService.kt
@@ -21,7 +21,6 @@ package de.cyface.synchronization
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
-import android.util.Log
 
 /**
  * The Android service used to communicate with the Stub Authenticator. This has been implemented as described in

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticatorService.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceAuthenticatorService.kt
@@ -28,8 +28,6 @@ import android.os.IBinder
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.0.7
- * @since 2.0.0
  */
 class CyfaceAuthenticatorService : Service() {
     /**

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceSyncService.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceSyncService.kt
@@ -19,7 +19,10 @@
 package de.cyface.synchronization
 
 import android.app.Service
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.os.IBinder
 import de.cyface.uploader.DefaultUploader
 import de.cyface.utils.Validate
@@ -46,7 +49,7 @@ class CyfaceSyncService : Service() {
                 syncAdapter = SyncAdapter(
                     applicationContext,
                     true,
-                    OAuth2(applicationContext, CyfaceAuthenticator.settings),
+                    OAuth2(applicationContext, CyfaceAuthenticator.settings, "CyfaceSyncService"),
                     DefaultUploader(collectorApi),
                 )
             }

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceSyncService.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/CyfaceSyncService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Cyface GmbH
+ * Copyright 2017-2024 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -19,10 +19,7 @@
 package de.cyface.synchronization
 
 import android.app.Service
-import android.content.ComponentName
-import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
 import android.os.IBinder
 import de.cyface.uploader.DefaultUploader
 import de.cyface.utils.Validate
@@ -37,8 +34,6 @@ import kotlinx.coroutines.runBlocking
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 1.0.9
- * @since 2.0.0
  */
 class CyfaceSyncService : Service() {
 

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/OAuth2.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/OAuth2.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Cyface GmbH
+ * Copyright 2023-2024 Cyface GmbH
  *
  * This file is part of the Cyface SDK for Android.
  *
@@ -50,12 +50,10 @@ import org.json.JSONObject
  * accounts, and handling sessions.
  *
  * @author Armin Schnabel
- * @version 1.0.0
- * @since 7.9.0
  * @param context The context to load settings and accounts from.
  * @param settings The settings which store the user preferences.
  */
-class OAuth2(context: Context, settings: SynchronizationSettings, private val caller: String) : Auth {
+class OAuth2(context: Context, settings: SynchronizationSettings, caller: String) : Auth {
 
     /**
      * The service used for authorization.
@@ -65,17 +63,14 @@ class OAuth2(context: Context, settings: SynchronizationSettings, private val ca
     /**
      * The authorization state.
      */
-    private var stateManager: AuthStateManager
+    private var stateManager: AuthStateManager = AuthStateManager.getInstance(context)
 
     /**
      * The configuration of the OAuth 2 endpoint to authorize against.
      */
-    private var configuration: Configuration
+    private var configuration: Configuration = Configuration.getInstance(context, settings)
 
     init {
-        // Authorization
-        stateManager = AuthStateManager.getInstance(context)
-        configuration = Configuration.getInstance(context, settings)
         /*if (config.hasConfigurationChanged()) {
             //throw IllegalArgumentException("config changed (SyncAdapter)")
             Toast.makeText(context, "Ignoring: config changed (SyncAdapter)", Toast.LENGTH_SHORT).show()
@@ -274,10 +269,12 @@ class OAuth2(context: Context, settings: SynchronizationSettings, private val ca
         }
 
         // Invalidate all tokens to ensure they are no longer used
-        authService.dispose()
+        dispose()
     }
 
-    // FIXME: Keep: login is currently just deactivated because it's buggy
+    /**
+     * Sends the end session request to the auth service to sign out the user.
+     */
     fun endSession(activity: FragmentActivity) {
         val currentState = stateManager.current
         val config = currentState.authorizationServiceConfiguration!!

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/OAuth2.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/OAuth2.kt
@@ -261,9 +261,10 @@ class OAuth2(context: Context, settings: SynchronizationSettings, caller: String
                 clearedState.update(currentState.lastRegistrationResponse)
             }
             stateManager.replace(clearedState)
-            // FIXME: completely delete AuthState.xml in sharedPreferences to fix credentials
-            // incorrect bug after logout and login during upload
-            stateManager.deletePreferencesFile()//clearState()
+
+            // [LEIP-233] Completely deleting the sharedPreferences/AuthState.xml file does not
+            // fix the `Credentials incorrect` error after re-login (app restart required)
+            //stateManager.deletePreferencesFile()
         } else {
             Log.w(TAG, "No authorization service configuration to sign out")
         }


### PR DESCRIPTION
This PR adds code required for logout from the UI.

**Attention: There is still a bug in the logout which leads to a `Credentials incorrect`  error after logging in with another account. You need to restart the app to fix this. But this is still better than no logout functionality.**