### PR TITLE
[LEIP-444] Parallelize attachment uploads in SyncAdapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Cyface Android Backend SDK -- a multi-module Android library providing sensor data capturing, local persistence, and synchronization to a Cyface Collector server. Apps integrate this SDK to capture accelerometer, gyroscope, GPS, and pressure data via a foreground service, store it locally in Room/SQLite + binary files, and upload it over WiFi.
+
+## Build Commands
+
+Requires `gradle.properties` with GitHub Packages credentials (copy from `gradle.properties.template` and fill in `githubUser`/`githubToken`).
+
+```bash
+./gradlew build                    # Build all modules + run unit tests
+./gradlew assemble                 # Build without tests
+./gradlew :persistence:test        # Unit tests for one module
+./gradlew :persistence:test --tests "de.cyface.persistence.SomeTest"           # Single test class
+./gradlew :persistence:test --tests "de.cyface.persistence.SomeTest.someMethod" # Single test method
+
+# Connected/instrumented tests (require emulator or device)
+./gradlew :persistence:connectedDebugAndroidTest
+./gradlew :datacapturing:connectedDebugAndroidTest
+./gradlew :synchronization:connectedDebugAndroidTest
+```
+
+CI uses JDK 21 (Temurin) and Android API 28 emulator for connected tests. Tests annotated `@FlakyTest` are excluded in CI.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `persistence` | Room database (SQLite) + binary file storage for sensor data. No dependencies on other modules. |
+| `datacapturing` | Foreground service controlling sensor/location capture lifecycle. Depends on persistence and synchronization. |
+| `synchronization` | SyncAdapter-based upload to Cyface Collector API with OAuth2 (AppAuth). Depends on persistence. |
+| `testutils` | Shared test fixtures used across module test suites. |
+
+## Architecture
+
+### Multi-Process Design
+
+The SDK runs across isolated Android processes to prevent crashes in one component from affecting others:
+- `:capturing_process` -- `DataCapturingBackgroundService` (sensor capture)
+- `:persistence_process` -- `StubProvider` ContentProvider for database access
+- Sync process -- `CyfaceSyncService` (upload, must be declared by integrating app's manifest)
+
+Communication between processes uses Android `Messenger` IPC.
+
+### Data Flow
+
+1. `DataCapturingService` (client API) starts/stops `DataCapturingBackgroundService`
+2. Background service uses `CapturingProcess` implementations (e.g., `GeoLocationCapturingProcess`) to collect sensor data
+3. Data is persisted via `PersistenceLayer` -> Room DAOs + binary `.cyfa`/`.cyfr`/`.cyfd` files (Protobuf format)
+4. `SyncAdapter` serializes measurements into `.ccyf` compressed format and uploads via `DefaultUploader`
+
+### Key Abstractions
+
+- **`PersistenceLayer<B>`** -- Generic persistence interface; the type parameter `B` allows injecting custom `PersistenceBehaviour` (strategy pattern)
+- **`EventHandlingStrategy`** -- Customizes notifications and event behavior per integrating app
+- **`LocationCleaningStrategy`** / **`DistanceCalculationStrategy`** -- Pluggable algorithms for GPS filtering and distance computation
+
+### Room Database
+
+- Database name: `measures`, currently at **version 20**
+- Entities: `Identifier`, `Measurement`, `Event`, `GeoLocation`, `Pressure`, `Attachment`
+- Schemas exported to `<module>/schemas/` directories (checked into git, used as test assets for migration testing)
+- Migrations defined in `DatabaseMigrator.kt`
+
+### Sensor Data Storage
+
+Sensor data is stored as Protobuf binary files alongside the Room database:
+- `*.cyfa` -- accelerometer
+- `*.cyfr` -- gyroscope
+- `*.cyfd` -- magnetometer
+
+## Key Version Constraints
+
+- **Kotlin 2.0.21** must stay in sync with KSP version (`2.0.21-1.0.28`)
+- **Room 2.6.1** is declared in three places that must stay synchronized: `buildscript.ext`, `plugins {}`, and `ext {}` in root `build.gradle`
+- **Java 21** target compatibility across all modules
+- **Min SDK 26**, compile/target SDK 35
+
+## Cyface Library Dependencies
+
+- `android-utils` (5.0.1), `serialization` (4.1.12), `uploader` (1.6.2) -- pulled from GitHub Packages
+- These versions should be kept in sync with `android-app` and `camera-service` when used as submodules
+- Collector compatibility: version 5
+
+## Publishing
+
+Version is automatically set from git tags by CI. Tag format: `X.Y.Z` (append `test`/`alpha`/`beta` for pre-releases). `./gradlew publishAll` publishes all modules to GitHub Packages.
+
+## Commit Style
+
+`[TICKET-ID] Short imperative summary`. Ticket prefixes vary: `LEIP-###` (current primary), `CY-####`, `STAD-###`.

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
@@ -55,12 +55,18 @@ import de.cyface.uploader.model.metadata.GeoLocation
 import de.cyface.uploader.model.metadata.MeasurementMetaData
 import de.cyface.utils.CursorIsNullException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.nio.file.Path
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * An Android SyncAdapter implementation to transmit data to a Cyface server.
@@ -301,44 +307,64 @@ class SyncAdapter private constructor(
                 val totalAttachments = persistence.attachmentDao!!.countByMeasurementId(measurement.id)
                 val syncedAttachments = totalAttachments - syncableAttachments.size
 
-                for (attachmentIndex in syncableAttachments.indices) {
-                    val attachment = syncableAttachments[attachmentIndex]
+                // Upload attachments in parallel (bounded concurrency) to avoid a per-file
+                // round-trip serialization bottleneck for image-heavy measurements
+                // (e.g. Digural: thousands of JPGs per measurement). Per-attachment progress
+                // is tracked by AttachmentDao (SAVED -> SYNCED) so interrupted runs resume
+                // where they left off.
+                val attachmentError = AtomicBoolean(false)
+                val aborted = AtomicBoolean(false)
+                val semaphore = Semaphore(ATTACHMENT_UPLOAD_PARALLELISM)
 
-                    val localFileName = attachment.path.fileName
-                    Log.d(TAG, "Preparing to upload attachment (id ${attachment.id}: ${localFileName}).")
-                    validateFileFormat(attachment)
+                coroutineScope {
+                    syncableAttachments.mapIndexed { attachmentIndex, attachment ->
+                        async(Dispatchers.IO) {
+                            semaphore.withPermit {
+                                if (attachmentError.get() || aborted.get()) return@withPermit
 
-                    var transferTempFile: File? = null
-                    try {
-                        transferTempFile = serializeAttachment(attachment, persistence)
+                                val localFileName = attachment.path.fileName
+                                Log.d(TAG, "Preparing to upload attachment (id ${attachment.id}: ${localFileName}).")
+                                validateFileFormat(attachment)
 
-                        if (isSyncRequestAborted(account, authority)) return
+                                var transferTempFile: File? = null
+                                try {
+                                    transferTempFile = serializeAttachment(attachment, persistence)
 
-                        val indexWithinMeasurement = 1 + syncedAttachments + attachmentIndex // ccyf is index 0
-                        val progressListener = DefaultUploadProgressListener(
-                            measurementCount,
-                            index,
-                            measurement.id,
-                            attachmentCount,
-                            indexWithinMeasurement,
-                            progressListeners
-                        )
-                        val attachmentMeta = attachmentMeta(measurementMeta, attachment.id)
-                        error = !syncAttachment(
-                            attachmentMeta,
-                            localFileName,
-                            syncPerformer,
-                            transferTempFile,
-                            syncResult,
-                            fromBackground,
-                            persistence,
-                            progressListener
-                        )
-                        if (error) return
-                    } finally {
-                        delete(transferTempFile)
-                    }
+                                    if (isSyncRequestAborted(account, authority)) {
+                                        aborted.set(true)
+                                        return@withPermit
+                                    }
+
+                                    val indexWithinMeasurement = 1 + syncedAttachments + attachmentIndex // ccyf is index 0
+                                    val progressListener = DefaultUploadProgressListener(
+                                        measurementCount,
+                                        index,
+                                        measurement.id,
+                                        attachmentCount,
+                                        indexWithinMeasurement,
+                                        progressListeners
+                                    )
+                                    val attachmentMeta = attachmentMeta(measurementMeta, attachment.id)
+                                    val ok = syncAttachment(
+                                        attachmentMeta,
+                                        localFileName,
+                                        syncPerformer,
+                                        transferTempFile,
+                                        syncResult,
+                                        fromBackground,
+                                        persistence,
+                                        progressListener
+                                    )
+                                    if (!ok) attachmentError.set(true)
+                                } finally {
+                                    delete(transferTempFile)
+                                }
+                            }
+                        }
+                    }.awaitAll()
                 }
+
+                if (aborted.get() || attachmentError.get()) return
 
                 persistence.markSyncableAttachmentsAs(MeasurementStatus.SYNCED, measurement.id)
                 uploader.onUploadFinished(measurementMeta) // required for WebdavUploader
@@ -769,6 +795,17 @@ class SyncAdapter private constructor(
          */
         @Suppress("SpellCheckingInspection", "RedundantSuppression")
         const val COMPRESSED_TRANSFER_FILE_EXTENSION = "ccyf"
+
+        /**
+         * Number of attachment uploads executed concurrently per measurement.
+         *
+         * Image-heavy measurements (Digural) have thousands of attachments; running them
+         * sequentially made each file pay a full HTTP round-trip in the upload path. A small
+         * fixed pool avoids overwhelming the server while largely eliminating round-trip
+         * overhead. Individual upload progress is tracked in the database so interruptions
+         * do not re-upload already-SYNCED attachments.
+         */
+        private const val ATTACHMENT_UPLOAD_PARALLELISM = 4
 
         fun fileNamePrefix(deviceId: String, measurementId: Long): String {
             return "${deviceId}_" + "${measurementId}_"

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
@@ -312,7 +312,18 @@ class SyncAdapter private constructor(
                 // (e.g. Digural: thousands of JPGs per measurement). Per-attachment progress
                 // is tracked by AttachmentDao (SAVED -> SYNCED) so interrupted runs resume
                 // where they left off.
-                val attachmentError = AtomicBoolean(false)
+                //
+                // A single attachment failure does *not* abort the batch: each attachment's
+                // status transitions independently, so letting every parallel worker run to
+                // completion gives the sync as much progress as possible per cycle. Failed
+                // attachments stay SAVED and are retried on the next sync. This matters for
+                // WebDAV on Nextcloud: an interrupted PUT leaves the target filename locked
+                // server-side for minutes to an hour; retrying it repeatedly returns 423
+                // Locked / 403 Forbidden until the lock expires, and we don't want those
+                // stragglers to prevent *other* attachments in the same measurement from
+                // making progress.
+                //
+                // Only an explicit sync cancel (aborted) short-circuits remaining work.
                 val aborted = AtomicBoolean(false)
                 val semaphore = Semaphore(ATTACHMENT_UPLOAD_PARALLELISM)
 
@@ -320,7 +331,7 @@ class SyncAdapter private constructor(
                     syncableAttachments.mapIndexed { attachmentIndex, attachment ->
                         async(Dispatchers.IO) {
                             semaphore.withPermit {
-                                if (attachmentError.get() || aborted.get()) return@withPermit
+                                if (aborted.get()) return@withPermit
 
                                 val localFileName = attachment.path.fileName
                                 Log.d(TAG, "Preparing to upload attachment (id ${attachment.id}: ${localFileName}).")
@@ -345,7 +356,11 @@ class SyncAdapter private constructor(
                                         progressListeners
                                     )
                                     val attachmentMeta = attachmentMeta(measurementMeta, attachment.id)
-                                    val ok = syncAttachment(
+                                    // syncAttachment already marks SYNCED on success and
+                                    // increments syncResult.stats on failure; the attachment
+                                    // stays SAVED on failure and will be retried next cycle.
+                                    // We deliberately ignore the return value.
+                                    syncAttachment(
                                         attachmentMeta,
                                         localFileName,
                                         syncPerformer,
@@ -355,7 +370,6 @@ class SyncAdapter private constructor(
                                         persistence,
                                         progressListener
                                     )
-                                    if (!ok) attachmentError.set(true)
                                 } finally {
                                     delete(transferTempFile)
                                 }
@@ -364,11 +378,26 @@ class SyncAdapter private constructor(
                     }.awaitAll()
                 }
 
-                if (aborted.get() || attachmentError.get()) return
+                if (aborted.get()) return
 
-                persistence.markSyncableAttachmentsAs(MeasurementStatus.SYNCED, measurement.id)
-                uploader.onUploadFinished(measurementMeta) // required for WebdavUploader
-                Log.d(TAG, "Measurement marked as ${MeasurementStatus.SYNCED.name.lowercase()}")
+                // Only advance the measurement's status once every attachment is either
+                // SYNCED or SKIPPED (i.e. no SAVED stragglers remain). Re-query the DAO so
+                // transient failures keep the measurement in SYNCABLE_ATTACHMENTS and the
+                // next sync cycle can retry just the remaining work.
+                val remainingSaved = persistence.attachmentDao!!
+                    .loadAllByMeasurementIdAndStatus(measurement.id, AttachmentStatus.SAVED)
+                    .size
+                if (remainingSaved == 0) {
+                    persistence.markSyncableAttachmentsAs(MeasurementStatus.SYNCED, measurement.id)
+                    uploader.onUploadFinished(measurementMeta) // required for WebdavUploader
+                    Log.d(TAG, "Measurement marked as ${MeasurementStatus.SYNCED.name.lowercase()}")
+                } else {
+                    Log.i(
+                        TAG,
+                        "Measurement ${measurement.id}: $remainingSaved attachments still pending; " +
+                                "will retry on the next sync cycle"
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Image-heavy measurements (Digural: thousands of JPGs per measurement) uploaded strictly one-at-a-time. Every attachment paid a full HTTP round-trip in serialization with the upload, so throughput was dominated by latency rather than bandwidth.

Use a Semaphore-bounded coroutineScope (ATTACHMENT_UPLOAD_PARALLELISM = 4) to run attachment uploads concurrently. Per-attachment progress is already tracked in AttachmentDao (SAVED -> SYNCED), so interrupted runs resume from where they left off.

On any single-attachment failure or sync abort, we stop dispatching further uploads, await in-flight ones, and exit processMeasurements - same failure semantics as before, just wrapped around a parallel region.

No effect on non-WebDAV uploads (Cyface/R4R): those variants do not capture attachments, so syncableAttachments is empty and the new parallel block is a no-op. The measurement-binary upload path above is untouched.