### PR TITLE
[LEIP-444] Make NoLocationData visible via ErrorHandler (-> Sentry)

### DIFF
--- a/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.kt
+++ b/synchronization/src/main/java/de/cyface/synchronization/ErrorHandler.kt
@@ -138,6 +138,9 @@ class ErrorHandler : BroadcastReceiver() {
             ErrorCode.ACCOUNT_NOT_ACTIVATED -> errorMessage =
                 context.getString(R.string.error_message_account_not_activated)
 
+            ErrorCode.NO_LOCATION_DATA -> errorMessage =
+                context.getString(R.string.error_message_no_location_data)
+
             else -> errorMessage = context.getString(R.string.error_message_unknown_error)
         }
         for (errorListener in errorListeners) {
@@ -178,7 +181,9 @@ class ErrorHandler : BroadcastReceiver() {
         UPLOAD_SESSION_EXPIRED(
             20
         ),
-        UNEXPECTED_RESPONSE_CODE(21), ACCOUNT_NOT_ACTIVATED(22); // MEASUREMENT_ENTRY_IS_IRRETRIEVABLE(X),
+        UNEXPECTED_RESPONSE_CODE(21), ACCOUNT_NOT_ACTIVATED(22), NO_LOCATION_DATA(
+            23
+        ); // MEASUREMENT_ENTRY_IS_IRRETRIEVABLE(X),
 
         companion object {
             fun getValueForCode(code: Int): ErrorCode? {

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/SyncPerformer.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/SyncPerformer.kt
@@ -312,7 +312,18 @@ internal class SyncPerformer(private val context: Context, private val fromBackg
 
             is NoLocationData -> {
                 syncResult.stats.numSkippedEntries++
-                Log.d(TAG, e.message!!)
+                Log.w(TAG, e.message!!)
+                // Surface as ErrorIntent so Application-level error listeners can forward to
+                // Sentry (if opt-in) - otherwise this is a silent permanent skip with no
+                // visibility on field devices. Legitimate cause: measurement captured entirely
+                // indoors / too briefly to get a GPS fix; the attachments stay on-device and
+                // never upload, so we at least want to know it happened.
+                ErrorHandler.sendErrorIntent(
+                    context,
+                    ErrorCode.NO_LOCATION_DATA.code,
+                    e.message,
+                    fromBackground
+                )
                 Result.UPLOAD_SKIPPED
             }
 

--- a/synchronization/src/main/res/values-de/strings.xml
+++ b/synchronization/src/main/res/values-de/strings.xml
@@ -29,6 +29,7 @@
     <string name="error_message_upload_session_expired">Upload Sitzung abgelaufen.</string>
     <string name="error_message_unexpected_response_code">Server Antworttyp unerwartet</string>
     <string name="error_message_account_not_activated">Nutzerkonto nicht aktiviert. Bitte E-Mails prüfen.</string>
+    <string name="error_message_no_location_data">Messung übersprungen: keine GPS-Daten vorhanden</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unerwarteter Fehler</string>

--- a/synchronization/src/main/res/values/strings.xml
+++ b/synchronization/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="error_message_upload_session_expired">Upload session expired.</string>
     <string name="error_message_unexpected_response_code">Unexpected response code</string>
     <string name="error_message_account_not_activated">Account not activated. Please check your emails.</string>
+    <string name="error_message_no_location_data">Measurement skipped: no location data recorded</string>
 
     <!-- Other errors -->
     <string name="error_message_unknown_error">Unexpected error</string>


### PR DESCRIPTION
Previously when a measurement/attachment had no location data, SyncPerformer.handleUploadFailed silently returned UPLOAD_SKIPPED with only a Log.d. The measurement was permanently marked SKIPPED and its attachments never uploaded, with zero visibility: no toast, no error intent, no Sentry event.

Legitimate triggers (short indoor tests, etc.) do exist, so we can't promote this to a hard failure. Instead, send an ErrorCode .NO_LOCATION_DATA via ErrorHandler.sendErrorIntent so application- level error listeners can see it. Digural's existing Application .errorListener already forwards any ErrorCode to Sentry when the user has opted in to error reporting, so no Sentry dep is added to android-backend.

Adds a new enum value, a de/en string resource, and upgrades the existing Log.d to Log.w so the event is also visible in logcat breadcrumbs.