### PR TITLE
[BIK-445] Trust (network, capabilities) in NetworkCallback; fall back…

### DIFF
--- a/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.kt
+++ b/synchronization/src/main/java/de/cyface/synchronization/NetworkCallback.kt
@@ -52,18 +52,28 @@ class NetworkCallback internal constructor(
             require(capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED))
         }
 
-        // Syncable ("not metered") filter is already included
+        // Trust the (network, capabilities) we were handed, do NOT re-query
+        // ConnectivityManager.activeNetwork here. activeNetwork can still be null (or point to the
+        // previous default) while Android is handing off the default route, so the old code could
+        // miss the transition entirely and stay "disconnected" until another callback fires. With
+        // weak / flapping Wi-Fi on kiosk devices (BIK-445, Digural trucks) the next callback may
+        // never arrive, leaving sync disabled for hours.
+        val isSyncableNow = isSyncable(capabilities)
         val isConnected = surveyor.isConnected
-        val isConnectedToSyncableNetwork = surveyor.isConnectedToSyncableNetwork
-        val syncableConnectionLost = isConnected && !isConnectedToSyncableNetwork
-        val syncableConnectionEstablished = !isConnected && isConnectedToSyncableNetwork
-        if (syncableConnectionEstablished) {
-            Log.v(TAG, "onCapabilitiesChanged.connectionEstablished: setConnected to true")
+        if (isSyncableNow && !isConnected) {
+            Log.v(TAG, "onCapabilitiesChanged.connectionEstablished (network=$network): setConnected to true")
             surveyor.setConnected(true)
-        } else if (syncableConnectionLost) {
-            // This should not be necessary as we have onLost() but we keep it as a safety net for now
-            Log.v(TAG, "onCapabilitiesChanged.connectionLost: setConnected to false.")
+        } else if (!isSyncableNow && isConnected) {
+            // onLost() is the primary path for disconnects; keep this as a safety net.
+            Log.v(TAG, "onCapabilitiesChanged.connectionLost (network=$network): setConnected to false.")
             surveyor.setConnected(false)
         }
+    }
+
+    private fun isSyncable(capabilities: NetworkCapabilities): Boolean {
+        val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        if (!hasInternet) return false
+        val isUnMetered = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+        return isUnMetered || !surveyor.isSyncOnUnMeteredNetworkOnly()
     }
 }

--- a/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.kt
+++ b/synchronization/src/main/java/de/cyface/synchronization/WiFiSurveyor.kt
@@ -323,39 +323,50 @@ class WiFiSurveyor(
          * [setSyncOnUnMeteredNetworkOnly] settings.
          */
         get() {
-            val activeNetworkInfo = connectivityManager.activeNetworkInfo
+            // Happy path: the system has already promoted a default network.
             val activeNetwork = connectivityManager.activeNetwork
-            val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
-            if (networkCapabilities == null) {
-                Log.w(
-                    TAG,
-                    "isConnectedToSyncableNetwork: returning false as networkCapabilities is null"
-                )
-                // This happened on Xiaomi Mi A2 Android 9.0 in the morning after capturing during the night
-                return false
-            }
-            val isUnMeteredNetwork =
-                networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
-
-            val isConnected = activeNetworkInfo != null && activeNetworkInfo.isConnected
-            val isSyncableConnection =
-                isConnected && (isUnMeteredNetwork || !syncOnUnMeteredNetworkOnly)
-
-            var networkType = "unconnected"
-            if (isConnected) {
-                networkType = if (isUnMeteredNetwork) {
-                    "unMetered"
-                } else {
-                    "metered"
+            val activeCaps = connectivityManager.getNetworkCapabilities(activeNetwork)
+            if (activeCaps != null) {
+                return isSyncable(activeCaps).also { result ->
+                    Log.v(
+                        TAG,
+                        "isConnectedToSyncableNetwork(active): $result " +
+                                "(un_metered=${activeCaps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)}, " +
+                                "internet=${activeCaps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)}, " +
+                                "syncOnUnMeteredOnly=$syncOnUnMeteredNetworkOnly)"
+                    )
                 }
             }
-            Log.v(
+
+            // Fallback: activeNetwork may be null between capability-change events, especially on
+            // kiosk devices with weak/flapping Wi-Fi (BIK-445). Scan known networks rather than
+            // giving up: sync was previously stuck disabled for hours after the first callback
+            // arrived with activeNetwork still null and no later callback re-evaluated state.
+            @Suppress("DEPRECATION")
+            val candidates = connectivityManager.allNetworks
+            for (candidate in candidates) {
+                val caps = connectivityManager.getNetworkCapabilities(candidate) ?: continue
+                if (isSyncable(caps)) {
+                    Log.v(
+                        TAG,
+                        "isConnectedToSyncableNetwork(fallback): true via $candidate"
+                    )
+                    return true
+                }
+            }
+            Log.d(
                 TAG,
-                "isConnectedToSyncableNetwork: " + isSyncableConnection + " (" + networkType + ", "
-                        + (if (syncOnUnMeteredNetworkOnly) "with" else "without") + " syncOnUnMeteredNetworkOnly)"
+                "isConnectedToSyncableNetwork: false (activeNetwork=null, ${candidates.size} candidate(s) scanned)"
             )
-            return isSyncableConnection
+            return false
         }
+
+    private fun isSyncable(capabilities: NetworkCapabilities): Boolean {
+        val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        if (!hasInternet) return false
+        val isUnMetered = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+        return isUnMetered || !syncOnUnMeteredNetworkOnly
+    }
 
     /**
      * Sets whether synchronization should happen only on

--- a/synchronization/src/test/java/de/cyface/synchronization/NetworkCallbackTest.kt
+++ b/synchronization/src/test/java/de/cyface/synchronization/NetworkCallbackTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Cyface GmbH
+ *
+ * This file is part of the Cyface SDK for Android.
+ *
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.synchronization
+
+import android.net.Network
+import android.net.NetworkCapabilities
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+/**
+ * Covers [NetworkCallback.onCapabilitiesChanged] and [NetworkCallback.onLost] after the BIK-445
+ * fix that made the callback trust the `(network, capabilities)` handed to it instead of
+ * re-querying [android.net.ConnectivityManager.activeNetwork].
+ *
+ * The cases worth pinning down:
+ * - unmetered wifi with internet while we default to "unmetered only" → syncable established
+ * - unmetered wifi without internet → not syncable (e.g. captive portal hasn't resolved yet)
+ * - metered network when opted in via `setSyncOnUnMeteredNetworkOnly(false)` → syncable
+ * - a syncable connection that becomes not-syncable on a capability change → disconnected
+ * - an already-connected surveyor that sees another unmetered callback → no redundant flip
+ * - `onLost` → disconnected
+ * - defensive: metered caps delivered while we filter for unmetered-only → require() trips
+ *   (OS filter should prevent this, but the belt-and-braces check stays)
+ */
+class NetworkCallbackTest {
+
+    private lateinit var surveyor: WiFiSurveyor
+    private lateinit var callback: NetworkCallback
+    private lateinit var network: Network
+
+    @Before
+    fun setUp() {
+        surveyor = mock(WiFiSurveyor::class.java)
+        network = mock(Network::class.java)
+        callback = NetworkCallback(surveyor)
+    }
+
+    @Test
+    fun `onCapabilitiesChanged on unmetered wifi with internet - not yet connected - sets connected`() {
+        `when`(surveyor.isSyncOnUnMeteredNetworkOnly()).thenReturn(true)
+        `when`(surveyor.isConnected).thenReturn(false)
+        val caps = capabilities(unMetered = true, hasInternet = true)
+
+        callback.onCapabilitiesChanged(network, caps)
+
+        verify(surveyor).setConnected(true)
+    }
+
+    @Test
+    fun `onCapabilitiesChanged on unmetered wifi without internet - no state change`() {
+        `when`(surveyor.isSyncOnUnMeteredNetworkOnly()).thenReturn(true)
+        `when`(surveyor.isConnected).thenReturn(false)
+        val caps = capabilities(unMetered = true, hasInternet = false)
+
+        callback.onCapabilitiesChanged(network, caps)
+
+        verify(surveyor, never()).setConnected(true)
+        verify(surveyor, never()).setConnected(false)
+    }
+
+    @Test
+    fun `onCapabilitiesChanged on metered network - opted in - sets connected`() {
+        `when`(surveyor.isSyncOnUnMeteredNetworkOnly()).thenReturn(false)
+        `when`(surveyor.isConnected).thenReturn(false)
+        val caps = capabilities(unMetered = false, hasInternet = true)
+
+        callback.onCapabilitiesChanged(network, caps)
+
+        verify(surveyor).setConnected(true)
+    }
+
+    @Test
+    fun `onCapabilitiesChanged flips to lost when syncable caps disappear - was connected`() {
+        // e.g. the same wifi loses NET_CAPABILITY_INTERNET (captive portal) while we stay attached
+        `when`(surveyor.isSyncOnUnMeteredNetworkOnly()).thenReturn(true)
+        `when`(surveyor.isConnected).thenReturn(true)
+        val caps = capabilities(unMetered = true, hasInternet = false)
+
+        callback.onCapabilitiesChanged(network, caps)
+
+        verify(surveyor).setConnected(false)
+    }
+
+    @Test
+    fun `onCapabilitiesChanged does not flip when already connected and still syncable`() {
+        `when`(surveyor.isSyncOnUnMeteredNetworkOnly()).thenReturn(true)
+        `when`(surveyor.isConnected).thenReturn(true)
+        val caps = capabilities(unMetered = true, hasInternet = true)
+
+        callback.onCapabilitiesChanged(network, caps)
+
+        verify(surveyor, never()).setConnected(true)
+        verify(surveyor, never()).setConnected(false)
+    }
+
+    @Test
+    fun `onLost sets connected to false`() {
+        callback.onLost(network)
+
+        verify(surveyor).setConnected(false)
+    }
+
+    @Test
+    fun `onCapabilitiesChanged with metered caps while unmetered-only is on - require trips`() {
+        // The OS filter (NetworkRequest NET_CAPABILITY_NOT_METERED) should prevent this entirely;
+        // the require() is a defensive check that we intentionally keep.
+        `when`(surveyor.isSyncOnUnMeteredNetworkOnly()).thenReturn(true)
+        val caps = capabilities(unMetered = false, hasInternet = true)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            callback.onCapabilitiesChanged(network, caps)
+        }
+    }
+
+    private fun capabilities(unMetered: Boolean, hasInternet: Boolean): NetworkCapabilities {
+        val caps = mock(NetworkCapabilities::class.java)
+        `when`(caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)).thenReturn(unMetered)
+        `when`(caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)).thenReturn(hasInternet)
+        return caps
+    }
+}

--- a/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorSyncableCheckTest.kt
+++ b/synchronization/src/test/java/de/cyface/synchronization/WiFiSurveyorSyncableCheckTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Cyface GmbH
+ *
+ * This file is part of the Cyface SDK for Android.
+ *
+ * The Cyface SDK for Android is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface SDK for Android is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface SDK for Android. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.synchronization
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+/**
+ * Covers [WiFiSurveyor.isConnectedToSyncableNetwork] after the BIK-445 fix that added an
+ * `allNetworks` fallback for the window in which [ConnectivityManager.getActiveNetwork] is still
+ * null while the system is promoting a new default route.
+ *
+ * The metered-network policy must survive the new fallback: when the surveyor is configured for
+ * unmetered-only, the fallback must never accept a metered cellular even when it is the only
+ * network with internet.
+ */
+class WiFiSurveyorSyncableCheckTest {
+
+    private lateinit var connectivityManager: ConnectivityManager
+    private lateinit var surveyor: WiFiSurveyor
+
+    @Before
+    fun setUp() {
+        val context = mock(Context::class.java)
+        connectivityManager = mock(ConnectivityManager::class.java)
+        surveyor = WiFiSurveyor(
+            context,
+            connectivityManager,
+            TestUtils.AUTHORITY,
+            TestUtils.ACCOUNT_TYPE
+        )
+        // surveyor defaults to syncOnUnMeteredNetworkOnly = true, matching production default.
+    }
+
+    // --- happy path: activeNetwork is populated ---------------------------------------------------
+
+    @Test
+    fun `happy path - active wifi is unmetered and has internet - syncable`() {
+        val wifi = mock(Network::class.java)
+        val wifiCaps = capabilities(unMetered = true, hasInternet = true)
+        `when`(connectivityManager.activeNetwork).thenReturn(wifi)
+        `when`(connectivityManager.getNetworkCapabilities(wifi)).thenReturn(wifiCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(true))
+    }
+
+    @Test
+    fun `happy path - active network is metered while unmetered-only - not syncable`() {
+        val cellular = mock(Network::class.java)
+        val cellularCaps = capabilities(unMetered = false, hasInternet = true)
+        `when`(connectivityManager.activeNetwork).thenReturn(cellular)
+        `when`(connectivityManager.getNetworkCapabilities(cellular)).thenReturn(cellularCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(false))
+    }
+
+    @Test
+    fun `happy path - active network has no internet capability - not syncable`() {
+        val wifi = mock(Network::class.java)
+        val wifiCaps = capabilities(unMetered = true, hasInternet = false)
+        `when`(connectivityManager.activeNetwork).thenReturn(wifi)
+        `when`(connectivityManager.getNetworkCapabilities(wifi)).thenReturn(wifiCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(false))
+    }
+
+    // --- fallback: activeNetwork null, scan allNetworks ------------------------------------------
+
+    @Test
+    fun `fallback - activeNetwork null with no networks at all - not syncable`() {
+        `when`(connectivityManager.activeNetwork).thenReturn(null)
+        @Suppress("DEPRECATION")
+        `when`(connectivityManager.allNetworks).thenReturn(emptyArray())
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(false))
+    }
+
+    @Test
+    fun `fallback - activeNetwork null with only a metered cellular - not syncable when unmetered-only`() {
+        // This is the exact case the user worried about: the system is mid-handoff, default route
+        // is null, and the only network visible to us is a metered cellular. We must refuse it
+        // because syncOnUnMeteredNetworkOnly is true (the default).
+        val cellular = mock(Network::class.java)
+        val cellularCaps = capabilities(unMetered = false, hasInternet = true)
+        `when`(connectivityManager.activeNetwork).thenReturn(null)
+        @Suppress("DEPRECATION")
+        `when`(connectivityManager.allNetworks).thenReturn(arrayOf(cellular))
+        `when`(connectivityManager.getNetworkCapabilities(cellular)).thenReturn(cellularCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(false))
+    }
+
+    @Test
+    fun `fallback - activeNetwork null with metered cellular plus unmetered wifi - syncable via wifi`() {
+        // Handoff in progress: both networks exist but neither is the default route yet. We want
+        // the wifi to be picked, never the cellular.
+        val cellular = mock(Network::class.java)
+        val wifi = mock(Network::class.java)
+        val cellularCaps = capabilities(unMetered = false, hasInternet = true)
+        val wifiCaps = capabilities(unMetered = true, hasInternet = true)
+        `when`(connectivityManager.activeNetwork).thenReturn(null)
+        @Suppress("DEPRECATION")
+        `when`(connectivityManager.allNetworks).thenReturn(arrayOf(cellular, wifi))
+        `when`(connectivityManager.getNetworkCapabilities(cellular)).thenReturn(cellularCaps)
+        `when`(connectivityManager.getNetworkCapabilities(wifi)).thenReturn(wifiCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(true))
+    }
+
+    @Test
+    fun `fallback - activeNetwork null with unmetered wifi alone - syncable`() {
+        val wifi = mock(Network::class.java)
+        val wifiCaps = capabilities(unMetered = true, hasInternet = true)
+        `when`(connectivityManager.activeNetwork).thenReturn(null)
+        @Suppress("DEPRECATION")
+        `when`(connectivityManager.allNetworks).thenReturn(arrayOf(wifi))
+        `when`(connectivityManager.getNetworkCapabilities(wifi)).thenReturn(wifiCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(true))
+    }
+
+    @Test
+    fun `fallback - unmetered wifi without internet should not qualify`() {
+        // Captive portal / association-only wifi: has NOT_METERED but hasn't earned INTERNET yet.
+        val wifi = mock(Network::class.java)
+        val wifiCaps = capabilities(unMetered = true, hasInternet = false)
+        `when`(connectivityManager.activeNetwork).thenReturn(null)
+        @Suppress("DEPRECATION")
+        `when`(connectivityManager.allNetworks).thenReturn(arrayOf(wifi))
+        `when`(connectivityManager.getNetworkCapabilities(wifi)).thenReturn(wifiCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(false))
+    }
+
+    @Test
+    fun `fallback - opted-in to metered - cellular alone is syncable`() {
+        // Flip the private flag directly: the public setter calls stopSurveillance() +
+        // startSurveillance(currentSynchronizationAccount!!) which can't run in a unit test
+        // (no registered account, no real ConnectivityManager).
+        setPrivateSyncOnUnMeteredNetworkOnly(surveyor, false)
+        val cellular = mock(Network::class.java)
+        val cellularCaps = capabilities(unMetered = false, hasInternet = true)
+        `when`(connectivityManager.activeNetwork).thenReturn(null)
+        @Suppress("DEPRECATION")
+        `when`(connectivityManager.allNetworks).thenReturn(arrayOf(cellular))
+        `when`(connectivityManager.getNetworkCapabilities(cellular)).thenReturn(cellularCaps)
+
+        assertThat(surveyor.isConnectedToSyncableNetwork, `is`(true))
+    }
+
+    private fun setPrivateSyncOnUnMeteredNetworkOnly(target: WiFiSurveyor, value: Boolean) {
+        val field = WiFiSurveyor::class.java.getDeclaredField("syncOnUnMeteredNetworkOnly")
+        field.isAccessible = true
+        field.setBoolean(target, value)
+    }
+
+    private fun capabilities(unMetered: Boolean, hasInternet: Boolean): NetworkCapabilities {
+        val caps = mock(NetworkCapabilities::class.java)
+        `when`(caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)).thenReturn(unMetered)
+        `when`(caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)).thenReturn(hasInternet)
+        return caps
+    }
+}


### PR DESCRIPTION
… to allNetworks

NetworkCallback.onCapabilitiesChanged previously re-queried ConnectivityManager.activeNetwork instead of using the (network, capabilities) it was handed. activeNetwork can still be null (or point to the previous default) while Android is handing off the default route, so we returned false on the first callback and the WiFiSurveyor stayed disconnected until another callback arrived - which on kiosk devices with weak/flapping Wi-Fi may never happen, leaving sync disabled for hours.

Use the passed capabilities directly in the callback. In the isConnectedToSyncableNetwork property getter (still used by startSurveillance, scheduleSyncNow and the legacy onReceive) fall back to scanning allNetworks when activeNetwork is null, so we recover instead of giving up. Extracted a shared isSyncable() helper.

Observed on Pixel 8 Pro Digural kiosks (BIK-445): breadcrumbs showed NETWORK_AVAILABLE fired but "isConnectedToSyncableNetwork: returning false as networkCapabilities is null" for every callback in a 16 s window, then no more callbacks, then no uploads for the rest of the day.