### PR TITLE
[LEIP-459] Fix OOM during measurement upload serialization

### DIFF
--- a/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
+++ b/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
@@ -40,6 +40,7 @@ import de.cyface.utils.CursorIsNullException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.BufferedOutputStream
+import java.io.FileInputStream
 import java.io.IOException
 import java.util.Locale
 
@@ -116,8 +117,7 @@ object TransferFileSerializer {
                     DataSerializable.humanReadableSize(accelerationFile.length(), true)
                 )
             )
-            val bytes = persistence.fileIOHandler.loadBytes(accelerationFile)
-            builder.accelerationsBinary = ByteString.copyFrom(bytes)
+            builder.accelerationsBinary = ByteString.readFrom(FileInputStream(accelerationFile))
         }
         if (rotationFile.exists()) {
             Log.v(
@@ -128,8 +128,7 @@ object TransferFileSerializer {
                     DataSerializable.humanReadableSize(rotationFile.length(), true)
                 )
             )
-            val bytes = persistence.fileIOHandler.loadBytes(rotationFile)
-            builder.rotationsBinary = ByteString.copyFrom(bytes)
+            builder.rotationsBinary = ByteString.readFrom(FileInputStream(rotationFile))
         }
         if (directionFile.exists()) {
             Log.v(
@@ -140,20 +139,16 @@ object TransferFileSerializer {
                     DataSerializable.humanReadableSize(directionFile.length(), true)
                 )
             )
-            val bytes = persistence.fileIOHandler.loadBytes(directionFile)
-            builder.directionsBinary = ByteString.copyFrom(bytes)
+            builder.directionsBinary = ByteString.readFrom(FileInputStream(directionFile))
         }
 
-        // Currently loading the whole measurement into memory (~ 5MB / hour serialized).
-        // - To add high-res image data in the future we cannot use the pre-compiled builder but
-        // have to stream the image data without loading it into memory to avoid an OOM exception.
         val transferFileHeader = DataSerializable.transferFileHeader()
-        val measurementBytes = builder.build().toByteArray()
+        val message = builder.build()
         try {
             // The stream must be closed by the caller in a finally catch
             withContext(Dispatchers.IO) {
                 bufferedOutputStream.write(transferFileHeader)
-                bufferedOutputStream.write(measurementBytes)
+                message.writeTo(bufferedOutputStream)
                 bufferedOutputStream.flush()
             }
         } catch (e: IOException) {
@@ -165,7 +160,7 @@ object TransferFileSerializer {
                 Locale.getDefault(),
                 "Serialized %s",
                 DataSerializable.humanReadableSize(
-                    (transferFileHeader.size + measurementBytes.size).toLong(),
+                    (transferFileHeader.size + message.serializedSize).toLong(),
                     true
                 )
             )

--- a/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
+++ b/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
@@ -142,6 +142,8 @@ object TransferFileSerializer {
             builder.directionsBinary = FileInputStream(directionFile).use { ByteString.readFrom(it) }
         }
 
+        // Whole measurement is in memory (~ 5 MB / hour serialized).
+        // writeTo() streams it to the output without a second copy via toByteArray().
         val transferFileHeader = DataSerializable.transferFileHeader()
         val message = builder.build()
         try {

--- a/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
+++ b/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
@@ -117,7 +117,7 @@ object TransferFileSerializer {
                     DataSerializable.humanReadableSize(accelerationFile.length(), true)
                 )
             )
-            builder.accelerationsBinary = ByteString.readFrom(FileInputStream(accelerationFile))
+            builder.accelerationsBinary = FileInputStream(accelerationFile).use { ByteString.readFrom(it) }
         }
         if (rotationFile.exists()) {
             Log.v(
@@ -128,7 +128,7 @@ object TransferFileSerializer {
                     DataSerializable.humanReadableSize(rotationFile.length(), true)
                 )
             )
-            builder.rotationsBinary = ByteString.readFrom(FileInputStream(rotationFile))
+            builder.rotationsBinary = FileInputStream(rotationFile).use { ByteString.readFrom(it) }
         }
         if (directionFile.exists()) {
             Log.v(
@@ -139,7 +139,7 @@ object TransferFileSerializer {
                     DataSerializable.humanReadableSize(directionFile.length(), true)
                 )
             )
-            builder.directionsBinary = ByteString.readFrom(FileInputStream(directionFile))
+            builder.directionsBinary = FileInputStream(directionFile).use { ByteString.readFrom(it) }
         }
 
         val transferFileHeader = DataSerializable.transferFileHeader()


### PR DESCRIPTION
## Summary
- Replace `builder.build().toByteArray()` with `message.writeTo(bufferedOutputStream)` in `TransferFileSerializer.loadSerialized()` to stream the protobuf message directly to the output instead of materializing it as a contiguous byte array. This eliminates a ~150 MB allocation for long recordings (~30 hours).
- Replace `loadBytes()` + `ByteString.copyFrom()` with `FileInputStream.use { ByteString.readFrom(it) }` for sensor files to avoid intermediate byte[] copies and properly close file descriptors.

Peak memory drops from ~3x to ~1x the sensor data size, keeping it within the 256 MB Android heap limit.

## Test plan
- [ ] Deploy to a Pixel 9 with the large (~30h) measurement that was crashing with OOM and verify it syncs successfully
- [ ] Verify a normal-sized measurement still uploads correctly (byte-for-byte identical output since `toByteArray()` internally calls `writeTo()`)
- [ ] Check logcat for the "Serialized ..." log line to confirm `serializedSize` reports correctly