### PR TITLE
[LEIP-461] Fix cursor leak and skip failed measurements during sync

### DIFF
--- a/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
+++ b/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
@@ -214,25 +214,22 @@ object TransferFileSerializer {
         persistence: PersistenceLayer<*>
     ): LocationRecords {
         val serializer = LocationSerializer()
-        var cursor: Cursor? = null
         try {
             val count = persistence.locationDao!!.countByMeasurementId(measurementId)
             var startIndex = 0
             while (startIndex < count) {
-                cursor = getLocationCursor(
+                getLocationCursor(
                     persistence.database!!,
                     measurementId,
                     startIndex,
                     DATABASE_QUERY_LIMIT,
-                )
-                //if (cursor == null) throw CursorIsNullException()
-                serializer.readFrom(cursor)
+                ).use { cursor ->
+                    serializer.readFrom(cursor)
+                }
                 startIndex += DATABASE_QUERY_LIMIT
             }
         } catch (e: RemoteException) {
             throw java.lang.IllegalStateException(e)
-        } finally {
-            cursor?.close()
         }
         return serializer.result()
     }

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
@@ -246,7 +246,6 @@ class SyncAdapter private constructor(
         authority: String
     ) {
         val measurementCount = measurements.size
-        var error: Boolean
 
         for (index in 0 until measurementCount) {
             val measurement = measurements[index]
@@ -279,7 +278,7 @@ class SyncAdapter private constructor(
                         indexWithinMeasurement,
                         progressListeners
                     )
-                    error = !syncMeasurement(
+                    val success = syncMeasurement(
                         measurement,
                         measurementMeta,
                         compressedTransferTempFile,
@@ -289,7 +288,17 @@ class SyncAdapter private constructor(
                         persistence,
                         progressListener
                     )
-                    if (error) return
+                    if (!success) {
+                        Log.w(TAG, "Measurement ${measurement.id} upload failed, skipping to next")
+                        syncResult.stats.numIoExceptions++
+                        continue
+                    }
+                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                    throw e
+                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                    Log.w(TAG, "Measurement ${measurement.id} serialization failed, skipping to next", e)
+                    syncResult.stats.numIoExceptions++
+                    continue
                 } finally {
                     delete(compressedTransferTempFile)
                 }


### PR DESCRIPTION
## Summary
- **Cursor leak fix**: `TransferFileSerializer.loadLocations()` created a new cursor each loop iteration but only closed the last one. Now uses `.use {}` to close each cursor immediately after processing, matching `loadEvents()`.
- **Skip failed measurements**: A single measurement upload failure (e.g. 423 Locked from a previous interrupted upload) used to abort the entire sync loop. Now logs the failure and continues to the next measurement. The failed measurement stays in FINISHED status and will be retried next cycle. Also catches serialization exceptions so one large/corrupt measurement doesn't block others.

## Test plan
- [ ] CI connected tests pass
- [ ] Deploy to Pixel 8 Pro with ~250 GB queued: verify sync progresses past the 423-locked measurement and uploads others
- [ ] Verify "A resource failed to call AbstractCursor.close" warnings are gone from logcat
- [ ] Verify failed measurements are retried on subsequent sync cycles (stay in FINISHED status)