### PR TITLE
[LEIP-461] Report serialization progress to prevent SyncManager timeout

### DIFF
--- a/persistence/src/main/kotlin/de/cyface/persistence/serialization/MeasurementSerializer.kt
+++ b/persistence/src/main/kotlin/de/cyface/persistence/serialization/MeasurementSerializer.kt
@@ -67,7 +67,8 @@ class MeasurementSerializer {
     @Throws(CursorIsNullException::class)
     suspend fun writeSerializedCompressed(
         measurementId: Long,
-        persistenceLayer: PersistenceLayer<*>
+        persistenceLayer: PersistenceLayer<*>,
+        onBatchSerialized: (() -> Unit)? = null
     ): File? {
 
         // Store the compressed bytes into a temp file to be able to read the byte size for transmission
@@ -85,7 +86,8 @@ class MeasurementSerializer {
                     loadSerializedCompressed(
                         fileOutputStream,
                         measurementId,
-                        persistenceLayer
+                        persistenceLayer,
+                        onBatchSerialized
                     )
                 }
             }
@@ -154,7 +156,8 @@ class MeasurementSerializer {
     private suspend fun loadSerializedCompressed(
         fileOutputStream: OutputStream,
         measurementId: Long,
-        persistenceLayer: PersistenceLayer<*>
+        persistenceLayer: PersistenceLayer<*>,
+        onBatchSerialized: (() -> Unit)? = null
     ) {
         Log.d(TAG, "loadSerializedCompressed: start")
         val startTimestamp = System.currentTimeMillis()
@@ -168,7 +171,7 @@ class MeasurementSerializer {
         val deflaterStream = DeflaterOutputStream(bufferedFileOutputStream, compressor)
         BufferedOutputStream(deflaterStream).use { outputStream ->
             // Injecting the outputStream into which the serialized (in this case compressed) data is written to
-            loadSerialized(outputStream, measurementId, persistenceLayer)
+            loadSerialized(outputStream, measurementId, persistenceLayer, onBatchSerialized)
             outputStream.flush()
         }
         compressor.end()

--- a/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
+++ b/persistence/src/main/kotlin/de/cyface/persistence/serialization/TransferFileSerializer.kt
@@ -73,11 +73,12 @@ object TransferFileSerializer {
     suspend fun loadSerialized(
         bufferedOutputStream: BufferedOutputStream,
         measurementIdentifier: Long,
-        persistence: PersistenceLayer<*>
+        persistence: PersistenceLayer<*>,
+        onBatchSerialized: (() -> Unit)? = null
     ) {
         // Load data from ContentProvider
-        val events = loadEvents(measurementIdentifier, persistence)
-        val locationRecords = loadLocations(measurementIdentifier, persistence)
+        val events = loadEvents(measurementIdentifier, persistence, onBatchSerialized)
+        val locationRecords = loadLocations(measurementIdentifier, persistence, onBatchSerialized)
 
         // Using the modified `MeasurementBytes` class to inject the sensor bytes without parsing
         val builder = MeasurementBytes.newBuilder()
@@ -178,7 +179,8 @@ object TransferFileSerializer {
     @Throws(CursorIsNullException::class)
     private suspend fun loadEvents(
         measurementId: Long,
-        persistence: PersistenceLayer<*>
+        persistence: PersistenceLayer<*>,
+        onBatchSerialized: (() -> Unit)? = null
     ): List<Event?> {
         val serializer = EventSerializer()
         try {
@@ -191,10 +193,10 @@ object TransferFileSerializer {
                     startIndex,
                     DATABASE_QUERY_LIMIT
                 ).use { cursor ->
-                    //if (cursor == null) throw CursorIsNullException()
                     serializer.readFrom(cursor)
                 }
                 startIndex += DATABASE_QUERY_LIMIT
+                onBatchSerialized?.invoke()
             }
         } catch (e: RemoteException) {
             throw java.lang.IllegalStateException(e)
@@ -211,7 +213,8 @@ object TransferFileSerializer {
     @Throws(CursorIsNullException::class)
     private suspend fun loadLocations(
         measurementId: Long,
-        persistence: PersistenceLayer<*>
+        persistence: PersistenceLayer<*>,
+        onBatchSerialized: (() -> Unit)? = null
     ): LocationRecords {
         val serializer = LocationSerializer()
         try {
@@ -227,6 +230,7 @@ object TransferFileSerializer {
                     serializer.readFrom(cursor)
                 }
                 startIndex += DATABASE_QUERY_LIMIT
+                onBatchSerialized?.invoke()
             }
         } catch (e: RemoteException) {
             throw java.lang.IllegalStateException(e)

--- a/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
+++ b/synchronization/src/main/kotlin/de/cyface/synchronization/SyncAdapter.kt
@@ -265,7 +265,7 @@ class SyncAdapter private constructor(
             if (measurement.status === MeasurementStatus.FINISHED) {
                 var compressedTransferTempFile: File? = null
                 try {
-                    compressedTransferTempFile = serializeMeasurement(measurement, persistence)
+                    compressedTransferTempFile = serializeMeasurement(measurement, persistence, syncResult)
 
                     if (isSyncRequestAborted(account, authority)) return
 
@@ -419,9 +419,14 @@ class SyncAdapter private constructor(
 
     private suspend fun serializeMeasurement(
         measurement: Measurement,
-        persistence: DefaultPersistenceLayer<DefaultPersistenceBehaviour?>
+        persistence: DefaultPersistenceLayer<DefaultPersistenceBehaviour?>,
+        syncResult: SyncResult
     ): File? {
-        return MeasurementSerializer().writeSerializedCompressed(measurement.id, persistence)
+        // Signal progress to SyncManager after each batch so it doesn't kill the sync
+        // for "making no progress" during long serializations (large measurements).
+        return MeasurementSerializer().writeSerializedCompressed(measurement.id, persistence) {
+            syncResult.stats.numInserts++
+        }
     }
 
     private suspend fun serializeAttachment(


### PR DESCRIPTION
## Summary
- Thread an `onBatchSerialized` callback from `SyncAdapter` through `MeasurementSerializer` down to `TransferFileSerializer.loadLocations()` and `loadEvents()`
- After each batch of 10,000 rows loaded from SQLite, increment `syncResult.stats.numInserts` to signal the SyncManager that the sync is making progress
- Prevents the "Detected sync making no progress" timeout that kills serialization of large measurements (8+ hours / 390+ km / 150+ MB sensor data)

## Context
On a Pixel 8 Pro with ~250 GB of measurement data, the first measurement to sync is 390 km long (~8+ hours). Serializing it from SQLite (millions of location rows in batches of 10k) takes longer than the SyncManager's ~2 minute inactivity watchdog. The SyncManager then interrupts the sync thread, preventing any upload from ever starting.

## Test plan
- [ ] CI connected tests pass
- [ ] Deploy to Pixel 8 Pro: verify large measurement serialization completes without "Detected sync making no progress" timeout
- [ ] Verify SyncManager log no longer shows the cancellation message